### PR TITLE
Qt project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ include(DawnGetPlatformInfo)
 include(DawnMakeStringPair)
 include(DawnReportResult)
 include(DawnSetCXXStandard)
+include(DawnAddCustomDummyTarget)
 
 dawn_get_compiler_info()
 dawn_get_platform_info()

--- a/src/gridtools/CMakeLists.txt
+++ b/src/gridtools/CMakeLists.txt
@@ -14,3 +14,7 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
+# Add a dummy target with all the source files so that they are included in a qt creator project
+dawn_add_custom_dummy_target(NAME qt_creator_parse_project_clang
+                             DIRECTORIES "clang")
+

--- a/test/integration-test/CMakeLists.txt
+++ b/test/integration-test/CMakeLists.txt
@@ -40,6 +40,10 @@ gtclang_add_integrationtest(NAME no-codegen
                             GRIDTOOLS_FLAGS ${gridtools_flags}
 )
 
+# Add a dummy target with all the source files so that they are included in a qt creator project
+dawn_add_custom_dummy_target(NAME qt_creator_parse_project
+                             DIRECTORIES ${directories})
+
 # Codegen tests require GridTools
 if(GTCLANG_HAS_GRIDTOOLS)
   list(APPEND directories_with_codegen ${directories} ${cwd}/CodeGen)

--- a/test/integration-test/CMakeLists.txt
+++ b/test/integration-test/CMakeLists.txt
@@ -41,7 +41,7 @@ gtclang_add_integrationtest(NAME no-codegen
 )
 
 # Add a dummy target with all the source files so that they are included in a qt creator project
-dawn_add_custom_dummy_target(NAME qt_creator_parse_project
+dawn_add_custom_dummy_target(NAME qt_creator_parse_project_integration_test
                              DIRECTORIES ${directories})
 
 # Codegen tests require GridTools


### PR DESCRIPTION
# Technical Description

Some files, like the integration tests .cpp of gtclang are not included in Qt projects since they are not part of any cmake target.
This creates functionality to add cpp files in a custom target (that does nothing) with the sole purpose that qt creator can add them to the project

This goes together with Meteoswiss-APN/dawn#27