### PR TITLE
gtclang_tester fixes

### DIFF
--- a/scripts/travis/gtclang-driver-test.sh
+++ b/scripts/travis/gtclang-driver-test.sh
@@ -51,6 +51,6 @@ ctest -C ${CONFIG} --output-on-failure --force-new-ctest-process                
      || fatal_error "failed to run tests"
 
 # Run regression tests
-bash ./gtclang-tester-no-codegen.sh || fatal_error "failed to run tests"
+bash ./gtclang-tester-no-codegen.sh --no-progressbar || fatal_error "failed to run tests"
 
 popd

--- a/test/integration-test/SIR/AccessTest.cpp
+++ b/test/integration-test/SIR/AccessTest.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -write-sir -fno-codegen -o %filename%_gen.cpp
-// EXPECTED_FILE: OUTPUT:%filename%_gen.sir REFERENCE:%filename%_gen_ref.sir
+// EXPECTED_FILE: OUTPUT:%filename%_gen.sir REFERENCE:%filename%_gen_ref.sir IGNORE:filename
 
 #include "gridtools/clang_dsl.hpp"
 

--- a/test/integration-test/SIR/AccessTest_gen_ref.sir
+++ b/test/integration-test/SIR/AccessTest_gen_ref.sir
@@ -1,5 +1,5 @@
 {
- "filename": "/code/gtclang-all/gtclang/test/integration-test/SIR/AccessTest.cpp",
+ "filename": "/home/thfabian/Desktop/gtclang/test/integration-test/SIR/AccessTest.cpp",
  "stencils": [
   {
    "name": "Test",
@@ -29,7 +29,11 @@
                   "left": {
                    "field_access_expr": {
                     "name": "b",
-                    "offset": [],
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
                     "argument_map": [
                      -1,
                      -1,
@@ -47,6 +51,7 @@
                     }
                    }
                   },
+                  "op": "=",
                   "right": {
                    "binary_operator": {
                     "left": {
@@ -60,7 +65,11 @@
                             "left": {
                              "field_access_expr": {
                               "name": "a",
-                              "offset": [],
+                              "offset": [
+                               1,
+                               0,
+                               0
+                              ],
                               "argument_map": [
                                -1,
                                -1,
@@ -82,7 +91,11 @@
                             "right": {
                              "field_access_expr": {
                               "name": "a",
-                              "offset": [],
+                              "offset": [
+                               -1,
+                               0,
+                               0
+                              ],
                               "argument_map": [
                                -1,
                                -1,
@@ -110,7 +123,11 @@
                           "right": {
                            "field_access_expr": {
                             "name": "a",
-                            "offset": [],
+                            "offset": [
+                             0,
+                             1,
+                             0
+                            ],
                             "argument_map": [
                              -1,
                              -1,
@@ -138,7 +155,11 @@
                         "right": {
                          "field_access_expr": {
                           "name": "a",
-                          "offset": [],
+                          "offset": [
+                           0,
+                           -1,
+                           0
+                          ],
                           "argument_map": [
                            -1,
                            -1,
@@ -166,7 +187,11 @@
                       "right": {
                        "field_access_expr": {
                         "name": "a",
-                        "offset": [],
+                        "offset": [
+                         0,
+                         0,
+                         -1
+                        ],
                         "argument_map": [
                          -1,
                          -1,
@@ -194,7 +219,11 @@
                     "right": {
                      "field_access_expr": {
                       "name": "a",
-                      "offset": [],
+                      "offset": [
+                       0,
+                       1,
+                       1
+                      ],
                       "argument_map": [
                        -1,
                        -1,

--- a/test/integration-test/SIR/CopyTest.cpp
+++ b/test/integration-test/SIR/CopyTest.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -write-sir -fno-codegen -o %filename%_gen.cpp
-// EXPECTED_FILE: OUTPUT:%filename%_gen.sir REFERENCE:%filename%_gen_ref.sir
+// EXPECTED_FILE: OUTPUT:%filename%_gen.sir REFERENCE:%filename%_gen_ref.sir IGNORE:filename
 
 #include "gridtools/clang_dsl.hpp"
 

--- a/test/integration-test/SIR/CopyTest_gen_ref.sir
+++ b/test/integration-test/SIR/CopyTest_gen_ref.sir
@@ -1,5 +1,5 @@
 {
- "filename": "/code/gtclang-all/gtclang/test/integration-test/SIR/CopyTest.cpp",
+ "filename": "/home/thfabian/Desktop/gtclang/test/integration-test/SIR/CopyTest.cpp",
  "stencils": [
   {
    "name": "Test",
@@ -29,7 +29,11 @@
                   "left": {
                    "field_access_expr": {
                     "name": "field_a",
-                    "offset": [],
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
                     "argument_map": [
                      -1,
                      -1,
@@ -47,10 +51,15 @@
                     }
                    }
                   },
+                  "op": "=",
                   "right": {
                    "field_access_expr": {
                     "name": "field_b",
-                    "offset": [],
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
                     "argument_map": [
                      -1,
                      -1,

--- a/test/integration-test/SIR/StencilFnCallTest.cpp
+++ b/test/integration-test/SIR/StencilFnCallTest.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -write-sir -fno-codegen -o %filename%_gen.cpp
-// EXPECTED_FILE: OUTPUT:%filename%_gen.sir REFERENCE:%filename%_gen_ref.sir
+// EXPECTED_FILE: OUTPUT:%filename%_gen.sir REFERENCE:%filename%_gen_ref.sir IGNORE:filename
 
 #include "gridtools/clang_dsl.hpp"
 

--- a/test/integration-test/SIR/StencilFnCallTest_gen_ref.sir
+++ b/test/integration-test/SIR/StencilFnCallTest_gen_ref.sir
@@ -1,5 +1,5 @@
 {
- "filename": "/code/gtclang-all/gtclang/test/integration-test/SIR/StencilFnCallTest.cpp",
+ "filename": "/home/thfabian/Desktop/gtclang/test/integration-test/SIR/StencilFnCallTest.cpp",
  "stencils": [
   {
    "name": "Test",
@@ -29,7 +29,11 @@
                   "left": {
                    "field_access_expr": {
                     "name": "b",
-                    "offset": [],
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
                     "argument_map": [
                      -1,
                      -1,
@@ -47,6 +51,7 @@
                     }
                    }
                   },
+                  "op": "=",
                   "right": {
                    "stencil_fun_call_expr": {
                     "callee": "fn",
@@ -54,7 +59,11 @@
                      {
                       "field_access_expr": {
                        "name": "a",
-                       "offset": [],
+                       "offset": [
+                        0,
+                        0,
+                        0
+                       ],
                        "argument_map": [
                         -1,
                         -1,
@@ -158,7 +167,11 @@
           "expr": {
            "field_access_expr": {
             "name": "a",
-            "offset": [],
+            "offset": [
+             0,
+             0,
+             0
+            ],
             "argument_map": [
              -1,
              -1,

--- a/test/utils/gtclang-tester/gtclang-tester.py
+++ b/test/utils/gtclang-tester/gtclang-tester.py
@@ -17,6 +17,7 @@
 ##===------------------------------------------------------------------------------------------===##
 
 from gtclang_tester.main import main
+from sys import exit
 
 if __name__ == '__main__':
-    main()
+    exit(main())

--- a/test/utils/gtclang-tester/gtclang_tester/config.py
+++ b/test/utils/gtclang-tester/gtclang_tester/config.py
@@ -33,3 +33,6 @@ class Config(object):
 
     # Generate reference files
     generate_reference = False
+
+    # Don't show any progressbar
+    no_progressbar = False

--- a/test/utils/gtclang-tester/gtclang_tester/main.py
+++ b/test/utils/gtclang-tester/gtclang_tester/main.py
@@ -35,6 +35,8 @@ def main():
     parser.add_option("--gridtools_flags", dest="gridtools_flags",
                       help="semicolon separated list of compile flags required to compile gridtools C++ code",
                       metavar="FLAGS")
+    parser.add_option("--no-progressbar", dest="no_progressbar", action="store_true",
+                      help="Don't show any progressbar")
     parser.add_option("-v", "--verbose", dest="verbose", action="store_true",
                       help="verbose logging")
     parser.add_option("-g", "--generate-reference", dest="generate_reference", action="store_true",
@@ -56,6 +58,9 @@ def main():
 
     if options.cxx:
         Config.cxx = options.cxx
+
+    if options.no_progressbar:
+        Config.no_progressbar = True
 
     if not args:
         report_fatal_error('no input directories given')

--- a/test/utils/gtclang-tester/gtclang_tester/parser.py
+++ b/test/utils/gtclang-tester/gtclang_tester/parser.py
@@ -138,7 +138,7 @@ class Parser(object):
 
             expected_file = self.__substitute_keywords(line, linenumber)
 
-            report_info("Parsed EXPECTED_ACCESSES as: %s" % expected_file)
+            report_info("Parsed EXPECTED_FILE as: \"%s\"" % expected_file)
             self.__test.add_expected_file_command(expected_file, self.__dir, self.__file,
                                                   linenumber)
 
@@ -209,6 +209,7 @@ class ExpectedFile(object):
     def __init__(self, command, dir, file, linenumber):
         self.__file_output = []
         self.__file_reference = []
+        self.__ignored_nodes = []
 
         commands = command.split(' ')
         for cmd in commands:
@@ -224,6 +225,12 @@ class ExpectedFile(object):
                 for ref_file in reference_cmd.split(','):
                     self.__file_reference.append(path.join(dir, ref_file))
 
+            ignore_idx = cmd.find("IGNORE:")
+            if ignore_idx >= 0:
+                ignored_nodes = cmd[ignore_idx + len("IGNORE:"):].rstrip()
+                for node in ignored_nodes.split(','):
+                    self.__ignored_nodes.append(node)
+
         if len(self.__file_output) != len(self.__file_reference):
             report_fatal_error(
                 "%s:%i: mismatch of number of output and reference files" % (file, linenumber))
@@ -233,6 +240,9 @@ class ExpectedFile(object):
 
     def get_reference_files(self):
         return self.__file_reference
+
+    def get_ignored_nodes(self):
+        return self.__ignored_nodes
 
 
 class Test(object):

--- a/test/utils/gtclang-tester/gtclang_tester/progressbar.py
+++ b/test/utils/gtclang-tester/gtclang_tester/progressbar.py
@@ -203,7 +203,34 @@ class TerminalController:
         return self.__valid
 
 
-class SimpleProgressBar:
+class ProgressBarInterface(object):
+    """
+    Abstract progressbar interface.
+    """
+
+    def update(self, percent, message):
+        raise NotImplementedError
+
+    def clear(self):
+        raise NotImplementedError
+
+
+class EmptyProgressbar(ProgressBarInterface):
+    """
+    Empty implementation of a progressbar.
+    """
+
+    def __init__(self):
+        pass
+
+    def update(self, percent, message):
+        pass
+
+    def clear(self):
+        pass
+
+
+class SimpleProgressBar(ProgressBarInterface):
     """
     A simple progress bar which doesn't need any terminal support.
 
@@ -244,7 +271,7 @@ class SimpleProgressBar:
             self.atIndex = None
 
 
-class ProgressBar:
+class ProgressBar(ProgressBarInterface):
     """
     A 3-line progress bar, which looks like::
     

--- a/test/utils/gtclang-tester/gtclang_tester/runner.py
+++ b/test/utils/gtclang-tester/gtclang_tester/runner.py
@@ -25,7 +25,7 @@ from time import time
 
 from .config import Config
 from .error import report_info
-from .progressbar import TerminalController, ProgressBar, SimpleProgressBar
+from .progressbar import TerminalController, ProgressBar, SimpleProgressBar, EmptyProgressbar
 from .utility import executeCommand, levenshtein
 
 
@@ -48,7 +48,10 @@ class TestRunner(object):
         self.__test_time = 0
 
         try:
-            self.__progressbar = ProgressBar(self.__term, 'Tests')
+            if Config.no_progressbar:
+                self.__progressbar = EmptyProgressbar()
+            else:
+                self.__progressbar = ProgressBar(self.__term, 'Tests')
         except ValueError:
             report_info("Failed to initialize advanced progressbar")
             self.__progressbar = SimpleProgressBar('Tests  ')

--- a/test/utils/gtclang-tester/gtclang_tester/runner.py
+++ b/test/utils/gtclang-tester/gtclang_tester/runner.py
@@ -128,6 +128,12 @@ class TestRunner(object):
                             self.add_failure(file, "EXECUTION", "%s" % e)
                             break
 
+                        # Filter ignored nodes
+                        if files.get_ignored_nodes():
+                            for node in files.get_ignored_nodes():
+                                del output_json[node]
+                                del reference_json[node]
+
                         output, reference = dumps(output_json), dumps(reference_json)
 
                         if output != reference:


### PR DESCRIPTION
## Technical Description

This PR fixes various issues with the integration testing framework:
  - Properly propagate a non-zero exit code to the system (travis was always passing before)
  - Allow to ignore keys in a JSON file comparison (this allows to ignore paths in a JSON file when testing on different machines) -- This was facilitate by extending the `EXPECTED_FILE` to also take a keyword `IGNORE`.
  - Add an option to disable the progressbar (useful for travis)
  - Update the references of the SIR serialization tests