### PR TITLE
fields with directions

### DIFF
--- a/src/gridtools/clang/storage_dsl.hpp
+++ b/src/gridtools/clang/storage_dsl.hpp
@@ -83,6 +83,390 @@ struct storage {
   operator double() const;
 };
 
+/**
+ * @brief Dummy 1-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_i : public storage {
+  storage_i();
+
+  storage_i& operator=(const storage&);
+  storage_i& operator+=(const storage&);
+  storage_i& operator-=(const storage&);
+  storage_i& operator/=(const storage&);
+  storage_i& operator*=(const storage&);
+
+  storage_i& operator()(int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_i& operator()(direction);
+  storage_i& operator()(dimension);
+  storage_i& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_i& operator()(dimension, dimension);
+
+  storage_i& operator()(dimension, direction);
+  storage_i& operator()(direction, dimension);
+  storage_i& operator()(direction, direction);
+  /** @} */
+
+  /**
+   * @name 3D access
+   * @{
+   */
+  storage_i& operator()(dimension, dimension, dimension);
+
+  storage_i& operator()(direction, direction, direction);
+  storage_i& operator()(dimension, direction, direction);
+  storage_i& operator()(direction, dimension, direction);
+  storage_i& operator()(direction, direction, dimension);
+  storage_i& operator()(dimension, dimension, direction);
+  storage_i& operator()(dimension, direction, dimension);
+  storage_i& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
+/**
+ * @brief Dummy 1-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_j : public storage {
+  storage_j();
+
+  storage_j& operator=(const storage&);
+  storage_j& operator+=(const storage&);
+  storage_j& operator-=(const storage&);
+  storage_j& operator/=(const storage&);
+  storage_j& operator*=(const storage&);
+
+  storage_j& operator()(int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_j& operator()(direction);
+  storage_j& operator()(dimension);
+  storage_j& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_j& operator()(dimension, dimension);
+
+  storage_j& operator()(dimension, direction);
+  storage_j& operator()(direction, dimension);
+  storage_j& operator()(direction, direction);
+  /** @} */
+
+  /**
+   * @name 3D access
+   * @{
+   */
+  storage_j& operator()(dimension, dimension, dimension);
+
+  storage_j& operator()(direction, direction, direction);
+  storage_j& operator()(dimension, direction, direction);
+  storage_j& operator()(direction, dimension, direction);
+  storage_j& operator()(direction, direction, dimension);
+  storage_j& operator()(dimension, dimension, direction);
+  storage_j& operator()(dimension, direction, dimension);
+  storage_j& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
+/**
+ * @brief Dummy 1-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_k : public storage {
+  storage_k();
+
+  storage_k& operator=(const storage&);
+  storage_k& operator+=(const storage&);
+  storage_k& operator-=(const storage&);
+  storage_k& operator/=(const storage&);
+  storage_k& operator*=(const storage&);
+
+  storage_k& operator()(int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_k& operator()(direction);
+  storage_k& operator()(dimension);
+  storage_k& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_k& operator()(dimension, dimension);
+
+  storage_k& operator()(dimension, direction);
+  storage_k& operator()(direction, dimension);
+  storage_k& operator()(direction, direction);
+  /** @} */
+
+  /**
+   * @name 3D access
+   * @{
+   */
+  storage_k& operator()(dimension, dimension, dimension);
+
+  storage_k& operator()(direction, direction, direction);
+  storage_k& operator()(dimension, direction, direction);
+  storage_k& operator()(direction, dimension, direction);
+  storage_k& operator()(direction, direction, dimension);
+  storage_k& operator()(dimension, dimension, direction);
+  storage_k& operator()(dimension, direction, dimension);
+  storage_k& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
+/**
+ * @brief Dummy 2-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_ij : public storage {
+  storage_ij();
+
+  storage_ij& operator=(const storage&);
+  storage_ij& operator+=(const storage&);
+  storage_ij& operator-=(const storage&);
+  storage_ij& operator/=(const storage&);
+  storage_ij& operator*=(const storage&);
+
+  storage_ij& operator()(int, int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_ij& operator()(dimension);
+
+  storage_ij& operator()(direction);
+  storage_ij& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_ij& operator()(dimension, dimension);
+
+  storage_ij& operator()(dimension, direction);
+  storage_ij& operator()(direction, dimension);
+  storage_ij& operator()(direction, direction);
+  /** @} */
+
+  /**
+   * @name 3D access
+   * @{
+   */
+  storage_ij& operator()(dimension, dimension, dimension);
+
+  storage_ij& operator()(direction, direction, direction);
+  storage_ij& operator()(dimension, direction, direction);
+  storage_ij& operator()(direction, dimension, direction);
+  storage_ij& operator()(direction, direction, dimension);
+  storage_ij& operator()(dimension, dimension, direction);
+  storage_ij& operator()(dimension, direction, dimension);
+  storage_ij& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
+/**
+ * @brief Dummy 2-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_ik : public storage {
+  storage_ik();
+
+  storage_ik& operator=(const storage&);
+  storage_ik& operator+=(const storage&);
+  storage_ik& operator-=(const storage&);
+  storage_ik& operator/=(const storage&);
+  storage_ik& operator*=(const storage&);
+
+  storage_ik& operator()(int, int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_ik& operator()(dimension);
+
+  storage_ik& operator()(direction);
+  storage_ik& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_ik& operator()(dimension, dimension);
+
+  storage_ik& operator()(dimension, direction);
+  storage_ik& operator()(direction, dimension);
+  storage_ik& operator()(direction, direction);
+  /** @} */
+
+  /**
+ * @name 3D access
+ * @{
+ */
+  storage_ik& operator()(dimension, dimension, dimension);
+
+  storage_ik& operator()(direction, direction, direction);
+  storage_ik& operator()(dimension, direction, direction);
+  storage_ik& operator()(direction, dimension, direction);
+  storage_ik& operator()(direction, direction, dimension);
+  storage_ik& operator()(dimension, dimension, direction);
+  storage_ik& operator()(dimension, direction, dimension);
+  storage_ik& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
+/**
+ * @brief Dummy 2-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_jk : public storage {
+  storage_jk();
+
+  storage_jk& operator=(const storage&);
+  storage_jk& operator+=(const storage&);
+  storage_jk& operator-=(const storage&);
+  storage_jk& operator/=(const storage&);
+  storage_jk& operator*=(const storage&);
+
+  storage_jk& operator()(int, int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_jk& operator()(dimension);
+
+  storage_jk& operator()(direction);
+  storage_jk& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_jk& operator()(dimension, dimension);
+
+  storage_jk& operator()(dimension, direction);
+  storage_jk& operator()(direction, dimension);
+  storage_jk& operator()(direction, direction);
+  /** @} */
+
+  /**
+ * @name 3D access
+ * @{
+ */
+  storage_jk& operator()(dimension, dimension, dimension);
+
+  storage_jk& operator()(direction, direction, direction);
+  storage_jk& operator()(dimension, direction, direction);
+  storage_jk& operator()(direction, dimension, direction);
+  storage_jk& operator()(direction, direction, dimension);
+  storage_jk& operator()(dimension, dimension, direction);
+  storage_jk& operator()(dimension, direction, dimension);
+  storage_jk& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
+/**
+ * @brief Dummy 3-dimensional storage
+ * @ingroup gridtools_clang
+ */
+struct storage_ijk {
+  storage_ijk();
+
+  template <typename T>
+  storage_ijk(T...);
+
+  storage_ijk& operator=(const storage&);
+  storage_ijk& operator+=(const storage&);
+  storage_ijk& operator-=(const storage&);
+  storage_ijk& operator/=(const storage&);
+  storage_ijk& operator*=(const storage&);
+
+  storage_ijk& operator()(int, int, int);
+
+  /**
+   * @name 1D access
+   * @{
+   */
+  storage_ijk& operator()(direction);
+  storage_ijk& operator()(dimension);
+  storage_ijk& operator()(offset);
+  /** @} */
+
+  /**
+   * @name 2D access
+   * @{
+   */
+
+  storage_ijk& operator()(dimension, dimension);
+
+  storage_ijk& operator()(dimension, direction);
+  storage_ijk& operator()(direction, dimension);
+  storage_ijk& operator()(direction, direction);
+  /** @} */
+
+  /**
+   * @name 3D access
+   * @{
+   */
+  storage_ijk& operator()(dimension, dimension, dimension);
+
+  storage_ijk& operator()(direction, direction, direction);
+  storage_ijk& operator()(dimension, direction, direction);
+  storage_ijk& operator()(direction, dimension, direction);
+  storage_ijk& operator()(direction, direction, dimension);
+  storage_ijk& operator()(dimension, dimension, direction);
+  storage_ijk& operator()(dimension, direction, dimension);
+  storage_ijk& operator()(direction, dimension, dimension);
+  /** @} */
+
+  operator double() const;
+};
+
 struct var {
   var();
 
@@ -149,11 +533,11 @@ using meta_data_scalar_t = meta_data;
 
 #ifndef GRIDTOOLS_CLANG_STORAGE_T_DEFINED
 using storage_t = storage;
-using storage_ijk_t = storage;
-using storage_ij_t = storage;
-using storage_i_t = storage;
-using storage_j_t = storage;
-using storage_k_t = storage;
+using storage_ijk_t = storage_ijk;
+using storage_ij_t = storage_ij;
+using storage_i_t = storage_i;
+using storage_j_t = storage_j;
+using storage_k_t = storage_k;
 using storage_scalar_t = storage;
 #endif
 

--- a/src/gridtools/clang/storage_dsl.hpp
+++ b/src/gridtools/clang/storage_dsl.hpp
@@ -22,6 +22,51 @@
 #include "gridtools/clang/offset.hpp"
 #include <type_traits>
 
+#define STORAGE_CLASS_DEFN(Type)                                                                   \
+  Type& operator=(const storage&);                                                                 \
+  Type& operator+=(const storage&);                                                                \
+  Type& operator-=(const storage&);                                                                \
+  Type& operator/=(const storage&);                                                                \
+  Type& operator*=(const storage&);                                                                \
+                                                                                                   \
+  /**                                                                                              \
+   * @name 1D access                                                                               \
+   * @{                                                                                            \
+   */                                                                                              \
+  Type& operator()(direction);                                                                     \
+                                                                                                   \
+  Type& operator()(dimension);                                                                     \
+  Type& operator()(offset);                                                                        \
+  /** @} */                                                                                        \
+                                                                                                   \
+  /**                                                                                              \
+   * @name 2D access                                                                               \
+   * @{                                                                                            \
+   */                                                                                              \
+  Type& operator()(dimension, dimension);                                                          \
+                                                                                                   \
+  Type& operator()(dimension, direction);                                                          \
+  Type& operator()(direction, dimension);                                                          \
+  Type& operator()(direction, direction);                                                          \
+  /** @} */                                                                                        \
+                                                                                                   \
+  /**                                                                                              \
+   * @name 3D access                                                                               \
+   * @{                                                                                            \
+   */                                                                                              \
+  Type& operator()(dimension, dimension, dimension);                                               \
+                                                                                                   \
+  Type& operator()(direction, direction, direction);                                               \
+  Type& operator()(dimension, direction, direction);                                               \
+  Type& operator()(direction, dimension, direction);                                               \
+  Type& operator()(direction, direction, dimension);                                               \
+  Type& operator()(dimension, dimension, direction);                                               \
+  Type& operator()(dimension, direction, dimension);                                               \
+  Type& operator()(direction, dimension, dimension);                                               \
+  /** @} */                                                                                        \
+                                                                                                   \
+  operator double() const;
+
 namespace gridtools {
 
 namespace clang {
@@ -36,323 +81,68 @@ struct storage {
   template <typename T>
   storage(T...);
 
-  storage& operator=(const storage&);
-  storage& operator+=(const storage&);
-  storage& operator-=(const storage&);
-  storage& operator/=(const storage&);
-  storage& operator*=(const storage&);
-
   storage& operator()(int, int, int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage& operator()(direction);
-  storage& operator()(dimension);
-  storage& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage& operator()(dimension, dimension);
-
-  storage& operator()(dimension, direction);
-  storage& operator()(direction, dimension);
-  storage& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  storage& operator()(dimension, dimension, dimension);
-
-  storage& operator()(direction, direction, direction);
-  storage& operator()(dimension, direction, direction);
-  storage& operator()(direction, dimension, direction);
-  storage& operator()(direction, direction, dimension);
-  storage& operator()(dimension, dimension, direction);
-  storage& operator()(dimension, direction, dimension);
-  storage& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage)
 };
 
 /**
- * @brief Dummy 1-dimensional storage
+ * @brief Dummy 1-dimensional i-storage
  * @ingroup gridtools_clang
  */
 struct storage_i : public storage {
   storage_i();
 
-  storage_i& operator=(const storage&);
-  storage_i& operator+=(const storage&);
-  storage_i& operator-=(const storage&);
-  storage_i& operator/=(const storage&);
-  storage_i& operator*=(const storage&);
-
   storage_i& operator()(int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_i& operator()(direction);
-  storage_i& operator()(dimension);
-  storage_i& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_i& operator()(dimension, dimension);
-
-  storage_i& operator()(dimension, direction);
-  storage_i& operator()(direction, dimension);
-  storage_i& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  storage_i& operator()(dimension, dimension, dimension);
-
-  storage_i& operator()(direction, direction, direction);
-  storage_i& operator()(dimension, direction, direction);
-  storage_i& operator()(direction, dimension, direction);
-  storage_i& operator()(direction, direction, dimension);
-  storage_i& operator()(dimension, dimension, direction);
-  storage_i& operator()(dimension, direction, dimension);
-  storage_i& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_i);
 };
 
 /**
- * @brief Dummy 1-dimensional storage
+ * @brief Dummy 1-dimensional j-storage
  * @ingroup gridtools_clang
  */
 struct storage_j : public storage {
   storage_j();
 
-  storage_j& operator=(const storage&);
-  storage_j& operator+=(const storage&);
-  storage_j& operator-=(const storage&);
-  storage_j& operator/=(const storage&);
-  storage_j& operator*=(const storage&);
-
   storage_j& operator()(int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_j& operator()(direction);
-  storage_j& operator()(dimension);
-  storage_j& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_j& operator()(dimension, dimension);
-
-  storage_j& operator()(dimension, direction);
-  storage_j& operator()(direction, dimension);
-  storage_j& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  storage_j& operator()(dimension, dimension, dimension);
-
-  storage_j& operator()(direction, direction, direction);
-  storage_j& operator()(dimension, direction, direction);
-  storage_j& operator()(direction, dimension, direction);
-  storage_j& operator()(direction, direction, dimension);
-  storage_j& operator()(dimension, dimension, direction);
-  storage_j& operator()(dimension, direction, dimension);
-  storage_j& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_j);
 };
 
 /**
- * @brief Dummy 1-dimensional storage
+ * @brief Dummy 1-dimensional k-storage
  * @ingroup gridtools_clang
  */
 struct storage_k : public storage {
   storage_k();
 
-  storage_k& operator=(const storage&);
-  storage_k& operator+=(const storage&);
-  storage_k& operator-=(const storage&);
-  storage_k& operator/=(const storage&);
-  storage_k& operator*=(const storage&);
-
   storage_k& operator()(int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_k& operator()(direction);
-  storage_k& operator()(dimension);
-  storage_k& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_k& operator()(dimension, dimension);
-
-  storage_k& operator()(dimension, direction);
-  storage_k& operator()(direction, dimension);
-  storage_k& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  storage_k& operator()(dimension, dimension, dimension);
-
-  storage_k& operator()(direction, direction, direction);
-  storage_k& operator()(dimension, direction, direction);
-  storage_k& operator()(direction, dimension, direction);
-  storage_k& operator()(direction, direction, dimension);
-  storage_k& operator()(dimension, dimension, direction);
-  storage_k& operator()(dimension, direction, dimension);
-  storage_k& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_k);
 };
-
 /**
- * @brief Dummy 2-dimensional storage
+ * @brief Dummy 2-dimensional ij-storage
  * @ingroup gridtools_clang
  */
 struct storage_ij : public storage {
   storage_ij();
 
-  storage_ij& operator=(const storage&);
-  storage_ij& operator+=(const storage&);
-  storage_ij& operator-=(const storage&);
-  storage_ij& operator/=(const storage&);
-  storage_ij& operator*=(const storage&);
-
   storage_ij& operator()(int, int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_ij& operator()(dimension);
-
-  storage_ij& operator()(direction);
-  storage_ij& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_ij& operator()(dimension, dimension);
-
-  storage_ij& operator()(dimension, direction);
-  storage_ij& operator()(direction, dimension);
-  storage_ij& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  storage_ij& operator()(dimension, dimension, dimension);
-
-  storage_ij& operator()(direction, direction, direction);
-  storage_ij& operator()(dimension, direction, direction);
-  storage_ij& operator()(direction, dimension, direction);
-  storage_ij& operator()(direction, direction, dimension);
-  storage_ij& operator()(dimension, dimension, direction);
-  storage_ij& operator()(dimension, direction, dimension);
-  storage_ij& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_ij);
 };
 
 /**
- * @brief Dummy 2-dimensional storage
+ * @brief Dummy 2-dimensional ik-storage
  * @ingroup gridtools_clang
  */
 struct storage_ik : public storage {
   storage_ik();
 
-  storage_ik& operator=(const storage&);
-  storage_ik& operator+=(const storage&);
-  storage_ik& operator-=(const storage&);
-  storage_ik& operator/=(const storage&);
-  storage_ik& operator*=(const storage&);
-
   storage_ik& operator()(int, int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_ik& operator()(dimension);
-
-  storage_ik& operator()(direction);
-  storage_ik& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_ik& operator()(dimension, dimension);
-
-  storage_ik& operator()(dimension, direction);
-  storage_ik& operator()(direction, dimension);
-  storage_ik& operator()(direction, direction);
-  /** @} */
-
-  /**
- * @name 3D access
- * @{
- */
-  storage_ik& operator()(dimension, dimension, dimension);
-
-  storage_ik& operator()(direction, direction, direction);
-  storage_ik& operator()(dimension, direction, direction);
-  storage_ik& operator()(direction, dimension, direction);
-  storage_ik& operator()(direction, direction, dimension);
-  storage_ik& operator()(dimension, dimension, direction);
-  storage_ik& operator()(dimension, direction, dimension);
-  storage_ik& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_ik);
 };
 
 /**
@@ -362,52 +152,9 @@ struct storage_ik : public storage {
 struct storage_jk : public storage {
   storage_jk();
 
-  storage_jk& operator=(const storage&);
-  storage_jk& operator+=(const storage&);
-  storage_jk& operator-=(const storage&);
-  storage_jk& operator/=(const storage&);
-  storage_jk& operator*=(const storage&);
-
   storage_jk& operator()(int, int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_jk& operator()(dimension);
-
-  storage_jk& operator()(direction);
-  storage_jk& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_jk& operator()(dimension, dimension);
-
-  storage_jk& operator()(dimension, direction);
-  storage_jk& operator()(direction, dimension);
-  storage_jk& operator()(direction, direction);
-  /** @} */
-
-  /**
- * @name 3D access
- * @{
- */
-  storage_jk& operator()(dimension, dimension, dimension);
-
-  storage_jk& operator()(direction, direction, direction);
-  storage_jk& operator()(dimension, direction, direction);
-  storage_jk& operator()(direction, dimension, direction);
-  storage_jk& operator()(direction, direction, dimension);
-  storage_jk& operator()(dimension, dimension, direction);
-  storage_jk& operator()(dimension, direction, dimension);
-  storage_jk& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_jk);
 };
 
 /**
@@ -417,105 +164,20 @@ struct storage_jk : public storage {
 struct storage_ijk {
   storage_ijk();
 
-  template <typename T>
-  storage_ijk(T...);
-
-  storage_ijk& operator=(const storage&);
-  storage_ijk& operator+=(const storage&);
-  storage_ijk& operator-=(const storage&);
-  storage_ijk& operator/=(const storage&);
-  storage_ijk& operator*=(const storage&);
-
   storage_ijk& operator()(int, int, int);
 
-  /**
-   * @name 1D access
-   * @{
-   */
-  storage_ijk& operator()(direction);
-  storage_ijk& operator()(dimension);
-  storage_ijk& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-
-  storage_ijk& operator()(dimension, dimension);
-
-  storage_ijk& operator()(dimension, direction);
-  storage_ijk& operator()(direction, dimension);
-  storage_ijk& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  storage_ijk& operator()(dimension, dimension, dimension);
-
-  storage_ijk& operator()(direction, direction, direction);
-  storage_ijk& operator()(dimension, direction, direction);
-  storage_ijk& operator()(direction, dimension, direction);
-  storage_ijk& operator()(direction, direction, dimension);
-  storage_ijk& operator()(dimension, dimension, direction);
-  storage_ijk& operator()(dimension, direction, dimension);
-  storage_ijk& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(storage_ijk);
 };
 
-struct var {
+struct var : public storage {
   var();
 
-  template <typename T>
-  var(T...);
+  var& operator()(int, int, int);
 
-  var& operator=(const var&);
-  var& operator+=(const var&);
-  var& operator-=(const var&);
-  var& operator/=(const var&);
-  var& operator*=(const var&);
-
-  /**
-   * @name 1D access
-   * @{
-   */
-  var& operator()(direction);
-  var& operator()(dimension);
-  var& operator()(offset);
-  /** @} */
-
-  /**
-   * @name 2D access
-   * @{
-   */
-  var& operator()(dimension, dimension);
-
-  var& operator()(dimension, direction);
-  var& operator()(direction, dimension);
-  var& operator()(direction, direction);
-  /** @} */
-
-  /**
-   * @name 3D access
-   * @{
-   */
-  var& operator()(dimension, dimension, dimension);
-
-  var& operator()(direction, direction, direction);
-  var& operator()(dimension, direction, direction);
-  var& operator()(direction, dimension, direction);
-  var& operator()(direction, direction, dimension);
-  var& operator()(dimension, dimension, direction);
-  var& operator()(dimension, direction, dimension);
-  var& operator()(direction, dimension, dimension);
-  /** @} */
-
-  operator double() const;
+  STORAGE_CLASS_DEFN(var);
 };
+
+#undef STORAGE_CLASS_DEFN
 
 #ifndef GRIDTOOLS_CLANG_META_DATA_T_DEFINED
 struct meta_data {

--- a/src/gtclang/Frontend/DiagnosticsKind.inc
+++ b/src/gtclang/Frontend/DiagnosticsKind.inc
@@ -83,4 +83,7 @@ DIAG(err_index_not_constexpr, clang::DiagnosticIDs::Error, "offset of index is n
 DIAG(err_index_illegal_argument, clang::DiagnosticIDs::Error, "index '%0' is not a valid argument of the enclosing stencil function")
 DIAG(err_index_invalid_type, clang::DiagnosticIDs::Error, "invalid type '%0' of index '%1'")
 
+// Offset
+DIAG(err_off_with_bad_storage_dim, clang::DiagnosticIDs::Error, "offset in field access %0 in bad dimension, only allowed in %1")
+
 // clang-format on

--- a/src/gtclang/Frontend/GTClangPreprocessorAction.cpp
+++ b/src/gtclang/Frontend/GTClangPreprocessorAction.cpp
@@ -393,8 +393,9 @@ private:
         // Get the token which describes the `storage`
         const Token& curToken = peekedTokens == 0 ? token_ : PP_.LookAhead(peekedTokens++);
 
-        if(curToken.is(tok::identifier) && (curToken.getIdentifierInfo()->getName() == "storage" ||
-                                            curToken.getIdentifierInfo()->getName() == "var")) {
+        if(curToken.is(tok::identifier) &&
+           ((curToken.getIdentifierInfo()->getName().find("storage") != std::string::npos) ||
+            curToken.getIdentifierInfo()->getName() == "var")) {
 
           if(stencilKind == SK_StencilFunction &&
              curToken.getIdentifierInfo()->getName() == "var") {

--- a/src/gtclang/Frontend/StencilParser.cpp
+++ b/src/gtclang/Frontend/StencilParser.cpp
@@ -20,6 +20,7 @@
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Casting.h"
 #include "dawn/Support/Logging.h"
+#include "dawn/Support/StringSwitch.h"
 #include "gtclang/Frontend/ClangASTStmtResolver.h"
 #include "gtclang/Frontend/GTClangContext.h"
 #include "gtclang/Frontend/GlobalVariableParser.h"
@@ -597,11 +598,22 @@ void StencilParser::parseStorage(clang::FieldDecl* field) {
   else
     typeStr = field->getType().getAsString();
 
-  if(typeStr == "storage") {
+  if(typeStr.find("storage") != std::string::npos) {
 
     DAWN_LOG(INFO) << "Parsing field: " << name;
     auto SIRField = std::make_shared<dawn::sir::Field>(name, getLocation(field));
     SIRField->IsTemporary = false;
+    SIRField->fieldDimensions = dawn::StringSwitch<dawn::Array3i>(typeStr)
+                                    .Case("storage", {{1, 1, 1}})
+                                    .Case("storage_i", {{1, 0, 0}})
+                                    .Case("storage_j", {{0, 1, 0}})
+                                    .Case("storage_k", {{0, 0, 1}})
+                                    .Case("storage_ij", {{1, 1, 0}})
+                                    .Case("storage_ik", {{1, 0, 1}})
+                                    .Case("storage_jk", {{0, 1, 1}})
+                                    .Case("storage_ijk", {{1, 1, 1}})
+                                    .Default({{-1, -1, -1}});
+    ;
     currentParserRecord_->CurrentStencil->Fields.emplace_back(SIRField);
     currentParserRecord_->addArgDecl(name, field);
 
@@ -610,6 +622,7 @@ void StencilParser::parseStorage(clang::FieldDecl* field) {
     DAWN_LOG(INFO) << "Parsing temporary field: " << name;
     auto SIRField = std::make_shared<dawn::sir::Field>(name, getLocation(field));
     SIRField->IsTemporary = true;
+    SIRField->fieldDimensions = {{1,1,1}};
     currentParserRecord_->CurrentStencil->Fields.emplace_back(SIRField);
     currentParserRecord_->addArgDecl(name, field);
 
@@ -637,6 +650,16 @@ void StencilParser::parseArgument(clang::FieldDecl* arg) {
     DAWN_LOG(INFO) << "Parsing field: " << name;
     auto SIRField = std::make_shared<dawn::sir::Field>(name, getLocation(arg));
     SIRField->IsTemporary = false;
+    SIRField->fieldDimensions = dawn::StringSwitch<dawn::Array3i>(typeStr)
+                                    .Case("storage", {{1, 1, 1}})
+                                    .Case("storage_i", {{1, 0, 0}})
+                                    .Case("storage_j", {{0, 1, 0}})
+                                    .Case("storage_k", {{0, 0, 1}})
+                                    .Case("storage_ij", {{1, 1, 0}})
+                                    .Case("storage_ik", {{1, 0, 1}})
+                                    .Case("storage_jk", {{0, 1, 1}})
+                                    .Case("storage_ijk", {{1, 1, 1}})
+                                    .Default({{0, 0, 0}});
     currentParserRecord_->CurrentStencilFunction->Args.emplace_back(SIRField);
     currentParserRecord_->addArgDecl(name, arg);
 

--- a/test/integration-test/SIR/AccessTest_gen_ref.sir
+++ b/test/integration-test/SIR/AccessTest_gen_ref.sir
@@ -1,5 +1,5 @@
 {
- "filename": "/home/thfabian/Desktop/gtclang/test/integration-test/SIR/AccessTest.cpp",
+ "filename": "/home/tobias/Documents/Work/gtclang/test/integration-test/SIR/AccessTest.cpp",
  "stencils": [
   {
    "name": "Test",
@@ -296,7 +296,12 @@
       "Line": 25,
       "Column": 11
      },
-     "is_temporary": false
+     "is_temporary": false,
+     "field_dimensions": [
+      1,
+      1,
+      1
+     ]
     },
     {
      "name": "b",
@@ -304,7 +309,12 @@
       "Line": 25,
       "Column": 14
      },
-     "is_temporary": false
+     "is_temporary": false,
+     "field_dimensions": [
+      1,
+      1,
+      1
+     ]
     }
    ]
   }

--- a/test/integration-test/SIR/CopyTest_gen_ref.sir
+++ b/test/integration-test/SIR/CopyTest_gen_ref.sir
@@ -1,5 +1,5 @@
 {
- "filename": "/home/thfabian/Desktop/gtclang/test/integration-test/SIR/CopyTest.cpp",
+ "filename": "/home/tobias/Documents/Work/gtclang/test/integration-test/SIR/CopyTest.cpp",
  "stencils": [
   {
    "name": "Test",
@@ -126,7 +126,12 @@
       "Line": 25,
       "Column": 11
      },
-     "is_temporary": false
+     "is_temporary": false,
+     "field_dimensions": [
+      1,
+      1,
+      1
+     ]
     },
     {
      "name": "field_b",
@@ -134,7 +139,12 @@
       "Line": 25,
       "Column": 20
      },
-     "is_temporary": false
+     "is_temporary": false,
+     "field_dimensions": [
+      1,
+      1,
+      1
+     ]
     }
    ]
   }

--- a/test/integration-test/SIR/StencilFnCallTest_gen_ref.sir
+++ b/test/integration-test/SIR/StencilFnCallTest_gen_ref.sir
@@ -137,7 +137,12 @@
       "Line": 32,
       "Column": 11
      },
-     "is_temporary": false
+     "is_temporary": false,
+     "field_dimensions": [
+      1,
+      1,
+      1
+     ]
     },
     {
      "name": "b",
@@ -145,7 +150,12 @@
       "Line": 32,
       "Column": 14
      },
-     "is_temporary": false
+     "is_temporary": false,
+     "field_dimensions": [
+      1,
+      1,
+      1
+     ]
     }
    ]
   }
@@ -213,7 +223,12 @@
        "Line": 25,
        "Column": 11
       },
-      "is_temporary": false
+      "is_temporary": false,
+      "field_dimensions": [
+       1,
+       1,
+       1
+      ]
      }
     }
    ]


### PR DESCRIPTION
(this goes with a PR in [Dawn](https://github.com/MeteoSwiss-APN/dawn/pull/85))

## Technical Description

This allows the user to specify the dimensionality of fields that are passed as input. Allowed inputs are:
```
storage
storage_i
storage_j
storage_k
storage_ij
storage_ik
storage_jk
storage_ijk
```
where the first and the last are the same

With this feature we gain two things:

* More error-checks are possible.
Currently you can pass a `storage_j_t` to the stencil and call it with i and k offsets. This can be prevented now if the user specifies the dimensionality of storages used.
* In the near future, there will be a Gridtools update that prohibits the notype-stencils that we currenly use.
In order for our setup to work, we need type information at the time of code-generation.