### PR TITLE
Move header file to prevent wrong halo setting

### DIFF
--- a/test/integration-test/CodeGen/boundary_condition_2_benchmark.cpp
+++ b/test/integration-test/CodeGen/boundary_condition_2_benchmark.cpp
@@ -15,10 +15,10 @@
 //===------------------------------------------------------------------------------------------===//
 #define GRIDTOOLS_CLANG_GENERATED 1
 #define GRIDTOOLS_CLANG_HALO_EXTEND 3
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/Options.hpp"
 #include "test/integration-test/CodeGen/generated/boundary_condition_2_c++-naive.cpp"
 #include "test/integration-test/CodeGen/generated/boundary_condition_2_gridtools.cpp"
+#include "gridtools/clang/verify.hpp"
 #include <gtest/gtest.h>
 
 using namespace dawn;

--- a/test/integration-test/CodeGen/boundary_condition_benchmark.cpp
+++ b/test/integration-test/CodeGen/boundary_condition_benchmark.cpp
@@ -15,10 +15,10 @@
 //===------------------------------------------------------------------------------------------===//
 #define GRIDTOOLS_CLANG_GENERATED 1
 #define GRIDTOOLS_CLANG_HALO_EXTEND 3
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/Options.hpp"
 #include "test/integration-test/CodeGen/generated/boundary_condition_c++-naive.cpp"
 #include "test/integration-test/CodeGen/generated/boundary_condition_gridtools.cpp"
+#include "gridtools/clang/verify.hpp"
 #include <gtest/gtest.h>
 
 #ifdef __CUDACC__

--- a/test/integration-test/CodeGen/copy_stencil_benchmark.cpp
+++ b/test/integration-test/CodeGen/copy_stencil_benchmark.cpp
@@ -16,9 +16,9 @@
 #define GRIDTOOLS_CLANG_GENERATED 1
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/copy_stencil_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/copy_stencil_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(copy_stencil, test) {

--- a/test/integration-test/CodeGen/coriolis_stencil_benchmark.cpp
+++ b/test/integration-test/CodeGen/coriolis_stencil_benchmark.cpp
@@ -16,9 +16,9 @@
 #define GRIDTOOLS_CLANG_GENERATED 1
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/coriolis_stencil_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/coriolis_stencil_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(coriolis_stencil, test) {

--- a/test/integration-test/CodeGen/globals_stencil_benchmark.cpp
+++ b/test/integration-test/CodeGen/globals_stencil_benchmark.cpp
@@ -16,9 +16,9 @@
 #define GRIDTOOLS_CLANG_GENERATED 1
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/globals_stencil_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/globals_stencil_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(globals_stencil, test) {

--- a/test/integration-test/CodeGen/hd_smagorinsky_benchmark.cpp
+++ b/test/integration-test/CodeGen/hd_smagorinsky_benchmark.cpp
@@ -19,9 +19,9 @@
 
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/hd_smagorinsky_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/hd_smagorinsky_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(hd_smagorinsky, test) {

--- a/test/integration-test/CodeGen/hori_diff_stencil_01_benchmark.cpp
+++ b/test/integration-test/CodeGen/hori_diff_stencil_01_benchmark.cpp
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/hori_diff_stencil_01_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/hori_diff_stencil_01_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(hori_diff_stencil_01, test) {

--- a/test/integration-test/CodeGen/hori_diff_stencil_02_benchmark.cpp
+++ b/test/integration-test/CodeGen/hori_diff_stencil_02_benchmark.cpp
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/hori_diff_stencil_02_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/hori_diff_stencil_02_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(hori_diff_stencil_02, test) {

--- a/test/integration-test/CodeGen/hori_diff_type2_stencil_benchmark.cpp
+++ b/test/integration-test/CodeGen/hori_diff_type2_stencil_benchmark.cpp
@@ -17,9 +17,9 @@
 #define GRIDTOOLS_CLANG_HALO_EXTEND 3
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/hori_diff_type2_stencil_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/hori_diff_type2_stencil_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(hori_diff_type2_stencil, test) {

--- a/test/integration-test/CodeGen/intervals_stencil_benchmark.cpp
+++ b/test/integration-test/CodeGen/intervals_stencil_benchmark.cpp
@@ -16,9 +16,9 @@
 #define GRIDTOOLS_CLANG_GENERATED 1
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/intervals_stencil_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/intervals_stencil_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 TEST(intervals_stencil, test) {

--- a/test/integration-test/CodeGen/nested_stencil_functions_benchmark.cpp
+++ b/test/integration-test/CodeGen/nested_stencil_functions_benchmark.cpp
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/nested_stencil_functions_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/nested_stencil_functions_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 namespace nsftest {

--- a/test/integration-test/CodeGen/stencil_desc_ast_benchmark.cpp
+++ b/test/integration-test/CodeGen/stencil_desc_ast_benchmark.cpp
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/stencil_desc_ast_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/stencil_desc_ast_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 

--- a/test/integration-test/CodeGen/stencil_functions_benchmark.cpp
+++ b/test/integration-test/CodeGen/stencil_functions_benchmark.cpp
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 #include "test/integration-test/CodeGen/Options.hpp"
-#include "gridtools/clang/verify.hpp"
 #include "test/integration-test/CodeGen/generated/stencil_functions_gridtools.cpp"
 #include "test/integration-test/CodeGen/generated/stencil_functions_c++-naive.cpp"
+#include "gridtools/clang/verify.hpp"
 
 using namespace dawn;
 


### PR DESCRIPTION
I had to move the header files in the integration tests folder due to wrong halo setting.
The problem lies in the inlcude file "storage_runtime.hpp". There we set the halo in the following way:
```c++
#ifdef GRIDTOOLS_CLANG_HALO_EXTEND
using halo_t = gridtools::halo<GRIDTOOLS_CLANG_HALO_EXTEND, GRIDTOOLS_CLANG_HALO_EXTEND, 0>;
using halo_ij_t = gridtools::halo<GRIDTOOLS_CLANG_HALO_EXTEND, GRIDTOOLS_CLANG_HALO_EXTEND, 0>;
using halo_i_t = gridtools::halo<GRIDTOOLS_CLANG_HALO_EXTEND, 0, 0>;
using halo_j_t = gridtools::halo<0, GRIDTOOLS_CLANG_HALO_EXTEND, 0>;
#else
using halo_ij_t = gridtools::halo<0, 0, 0>;
using halo_i_t = gridtools::halo<0, 0, 0>;
using halo_j_t = gridtools::halo<0, 0, 0>;
#endif
```
The define `GRIDTOOLS_CLANG_HALO_EXTEND` is set in the generated stencil. The benchmark of course has to include the generated file before the storage_runtime in order to retrieve the correct storage types. 