### PR TITLE
Add driver option to dump the clang AST

### DIFF
--- a/src/gtclang/Driver/Options.inc
+++ b/src/gtclang/Driver/Options.inc
@@ -36,6 +36,7 @@
 
 OPT(bool, Verbose, false, "verbose", "", "Enable verbose output by using step-by-step logging", "", false, false)
 OPT(bool, DumpSIR, false, "dump-sir", "", "Dump the parsed SIR to stdout", "", false, false)
+OPT(bool, DumpAST, false, "dump-ast", "", "Dump the clang AST of the preprocessed input to stdout", "", false, false)
 OPT(bool, WriteSIR, false, "write-sir", "", "Write the parsed SIR to stdout", "", false, false)
 OPT(bool, DumpPP, false, "dump-pp", "", "Dump the preprocessed code to stdout", "", false, false)
 OPT(std::string, OutputFile, "", "output", "o", "Write output to <file>", "<file>", true, false)

--- a/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -83,6 +83,11 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
   DAWN_LOG(INFO) << "Parsing translation unit... ";
 
   clang::TranslationUnitDecl* TU = ASTContext.getTranslationUnitDecl();
+
+  if(context_->getOptions().DumpAST) {
+    TU->dumpColor();
+  }
+
   for(auto& decl : TU->decls())
     visitor_->TraverseDecl(decl);
 


### PR DESCRIPTION
Minor improvement: While implementing the literal argument support for stencil_function construct expressions I found it quite useful to get a dump of the clang AST.