### PR TITLE
removal of the semicolons where needed

### DIFF
--- a/src/gtclang/Driver/Driver.cpp
+++ b/src/gtclang/Driver/Driver.cpp
@@ -42,7 +42,7 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   std::shared_ptr<dawn::SIR> returnSIR = nullptr;
 
   // Initialize the GTClangContext
-  auto context = llvm::make_unique<GTClangContext>();
+  std::unique_ptr<GTClangContext> context = llvm::make_unique<GTClangContext>();
 
   // Parse command-line options
   OptionsParser optionsParser(&context->getOptions());

--- a/src/gtclang/Driver/Options.inc
+++ b/src/gtclang/Driver/Options.inc
@@ -49,5 +49,6 @@ OPT(bool, CodeGen, true, "codegen", "", "Generate code", "", false, true)
 OPT(bool, ClangFormat, true, "clang-format", "", "Run clang-format on the generated code", "", false, true)
 OPT(bool, ReportPassPreprocessor, false, "report-pass-preprocessor", "", 
     "Print each line of the preprocessed source prepended by the line number (comments and indentation are removed)", "", false, true)
+OPT(bool, Serialized, false, "loaded-serialized", "", "is the passed file serialized data", "", false, true)
 
 // clang-format on

--- a/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -189,71 +189,83 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
   clang::FileManager files(clang::FileSystemOptions(), memFS);
   clang::SourceManager sources(context_->getASTContext().getDiagnostics(), files);
 
-  // Get a copy of the main-file's code
-  std::unique_ptr<llvm::MemoryBuffer> generatedCode =
-      llvm::MemoryBuffer::getMemBufferCopy(SM.getBufferData(SM.getMainFileID()));
-
-  // Create the generated file
-  DAWN_LOG(INFO) << "Creating generated file " << generatedFilename;
-  clang::FileID generatedFileID =
-      createInMemoryFile(generatedFilename, generatedCode.get(), sources, files, memFS.get());
-
-  // Replace clang DSL with gridtools
-  clang::Rewriter rewriter(sources, context_->getASTContext().getLangOpts());
-  for(const auto& stencilPair : stencilParser.getStencilMap()) {
-    clang::CXXRecordDecl* stencilDecl = stencilPair.first;
-    bool skipNewLines = false;
-    auto semiAfterDef = clang::Lexer::findLocationAfterToken(
-        stencilDecl->getSourceRange().getEnd(), clang::tok::semi, sources,
-        context_->getASTContext().getLangOpts(), skipNewLines);
-    if(rewriter.ReplaceText(
-           clang::SourceRange(stencilDecl->getSourceRange().getBegin(), semiAfterDef),
-           stencilPair.second->Attributes.has(dawn::sir::Attr::AK_NoCodeGen)
-               ? ""
-               : DawnTranslationUnit->getStencils().at(stencilPair.second->Name)))
-      context_->getDiagnostics().report(Diagnostics::err_fs_error) << dawn::format(
-          "unable to replace stencil code at: %s", stencilDecl->getLocation().printToString(SM));
-  }
-
-  // Replace globals struct
-  if(!globalsParser.isEmpty() && !DawnTranslationUnit->getGlobals().empty()) {
-    bool skipNewLines = false;
-    auto semiAfterDef = clang::Lexer::findLocationAfterToken(
-        globalsParser.getRecordDecl()->getSourceRange().getEnd(), clang::tok::semi, sources,
-        context_->getASTContext().getLangOpts(), skipNewLines);
-    if(rewriter.ReplaceText(
-           clang::SourceRange(globalsParser.getRecordDecl()->getSourceRange().getBegin(),
-                              semiAfterDef),
-           DawnTranslationUnit->getGlobals()))
-      context_->getDiagnostics().report(Diagnostics::err_fs_error)
-          << dawn::format("unable to replace globals code at: %s",
-                          globalsParser.getRecordDecl()->getLocation().printToString(SM));
-  }
-
-  // Replace interval
-  for(const clang::VarDecl* a : visitor_->getIntervalDecls()) {
-    bool skipNewLines = false;
-    auto semiAfterDef = clang::Lexer::findLocationAfterToken(
-        a->getSourceRange().getEnd(), clang::tok::semi, sources,
-        context_->getASTContext().getLangOpts(), skipNewLines);
-    rewriter.ReplaceText(clang::SourceRange(a->getSourceRange().getBegin(), semiAfterDef), "");
-  }
-
-  // Remove the code from stencil-functions
-  for(const auto& stencilFunPair : stencilParser.getStencilFunctionMap()) {
-    clang::CXXRecordDecl* stencilFunDecl = stencilFunPair.first;
-    bool skipNewLines = false;
-    auto semiAfterDef = clang::Lexer::findLocationAfterToken(
-        stencilFunDecl->getSourceRange().getEnd(), clang::tok::semi, sources,
-        context_->getASTContext().getLangOpts(), skipNewLines);
-    rewriter.ReplaceText(
-        clang::SourceRange(stencilFunDecl->getSourceRange().getBegin(), semiAfterDef), "");
-  }
-
   std::string code;
-  llvm::raw_string_ostream os(code);
-  rewriter.getEditBuffer(generatedFileID).write(os);
-  os.flush();
+  if(context_->getOptions().Serialized) {
+    DAWN_LOG(INFO) << "Data was loaded from serialized IR, codegen ";
+    std::cout << "Data was loaded from serialized IR, codegen " << std::endl;
+
+    code += DawnTranslationUnit->getGlobals();
+
+    code += "\n\n";
+
+    for(auto p : DawnTranslationUnit->getStencils()) {
+      code += p.second;
+    }
+  } else {
+    // Get a copy of the main-file's code
+    std::unique_ptr<llvm::MemoryBuffer> generatedCode =
+        llvm::MemoryBuffer::getMemBufferCopy(SM.getBufferData(SM.getMainFileID()));
+
+    // Create the generated file
+    DAWN_LOG(INFO) << "Creating generated file " << generatedFilename;
+    clang::FileID generatedFileID =
+        createInMemoryFile(generatedFilename, generatedCode.get(), sources, files, memFS.get());
+
+    // Replace clang DSL with gridtools
+    clang::Rewriter rewriter(sources, context_->getASTContext().getLangOpts());
+    for(const auto& stencilPair : stencilParser.getStencilMap()) {
+      clang::CXXRecordDecl* stencilDecl = stencilPair.first;
+      bool skipNewLines = false;
+      auto semiAfterDef = clang::Lexer::findLocationAfterToken(
+          stencilDecl->getSourceRange().getEnd(), clang::tok::semi, sources,
+          context_->getASTContext().getLangOpts(), skipNewLines);
+      if(rewriter.ReplaceText(
+             clang::SourceRange(stencilDecl->getSourceRange().getBegin(), semiAfterDef),
+             stencilPair.second->Attributes.has(dawn::sir::Attr::AK_NoCodeGen)
+                 ? ""
+                 : DawnTranslationUnit->getStencils().at(stencilPair.second->Name)))
+        context_->getDiagnostics().report(Diagnostics::err_fs_error) << dawn::format(
+            "unable to replace stencil code at: %s", stencilDecl->getLocation().printToString(SM));
+    }
+
+    // Replace globals struct
+    if(!globalsParser.isEmpty() && !DawnTranslationUnit->getGlobals().empty()) {
+      bool skipNewLines = false;
+      auto semiAfterDef = clang::Lexer::findLocationAfterToken(
+          globalsParser.getRecordDecl()->getSourceRange().getEnd(), clang::tok::semi, sources,
+          context_->getASTContext().getLangOpts(), skipNewLines);
+      if(rewriter.ReplaceText(
+             clang::SourceRange(globalsParser.getRecordDecl()->getSourceRange().getBegin(),
+                                semiAfterDef),
+             DawnTranslationUnit->getGlobals()))
+        context_->getDiagnostics().report(Diagnostics::err_fs_error)
+            << dawn::format("unable to replace globals code at: %s",
+                            globalsParser.getRecordDecl()->getLocation().printToString(SM));
+    }
+
+    // Replace interval
+    for(const clang::VarDecl* a : visitor_->getIntervalDecls()) {
+      bool skipNewLines = false;
+      auto semiAfterDef = clang::Lexer::findLocationAfterToken(
+          a->getSourceRange().getEnd(), clang::tok::semi, sources,
+          context_->getASTContext().getLangOpts(), skipNewLines);
+      rewriter.ReplaceText(clang::SourceRange(a->getSourceRange().getBegin(), semiAfterDef), "");
+    }
+
+    // Remove the code from stencil-functions
+    for(const auto& stencilFunPair : stencilParser.getStencilFunctionMap()) {
+      clang::CXXRecordDecl* stencilFunDecl = stencilFunPair.first;
+      bool skipNewLines = false;
+      auto semiAfterDef = clang::Lexer::findLocationAfterToken(
+          stencilFunDecl->getSourceRange().getEnd(), clang::tok::semi, sources,
+          context_->getASTContext().getLangOpts(), skipNewLines);
+      rewriter.ReplaceText(
+          clang::SourceRange(stencilFunDecl->getSourceRange().getBegin(), semiAfterDef), "");
+    }
+    llvm::raw_string_ostream os(code);
+    rewriter.getEditBuffer(generatedFileID).write(os);
+    os.flush();
+  }
 
   // Format the file
   if(context_->getOptions().ClangFormat) {


### PR DESCRIPTION
This fixes the issues that were arising with the trailing semicolons that were no longer removed due to the namespacing (this led to the fix that we had to implement this here properly instead of having the dirty fix in dawn that just removed trailing semicolons and left those in. 