### PR TITLE
adapt versioning tests to start with idx 0

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -90,8 +90,8 @@ yoda_find_package(
   REQUIRED_VARS dawn_DIR
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
-    GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
-    GIT_TAG "master" 
+    GIT_REPOSITORY "git@github.com:twicki/dawn.git"
+    GIT_TAG "metadata_fix_fv" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}
 )

--- a/test/integration-test/PassFieldVersioning/VersioingTest02.cpp
+++ b/test/integration-test/PassFieldVersioning/VersioingTest02.cpp
@@ -25,7 +25,7 @@ stencil Test {
 
   Do {
     vertical_region(k_start, k_end) {
-      field_a = field_a(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_1
+      field_a = field_a(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_0
     }
   }
 };

--- a/test/integration-test/PassFieldVersioning/VersioingTest03.cpp
+++ b/test/integration-test/PassFieldVersioning/VersioingTest03.cpp
@@ -25,7 +25,7 @@ stencil Test {
 
   Do {
     vertical_region(k_start, k_end) {
-      field_b = field_a(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_1
+      field_b = field_a(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_0
       field_a = field_b;
     }
   }

--- a/test/integration-test/PassFieldVersioning/VersioingTest04.cpp
+++ b/test/integration-test/PassFieldVersioning/VersioingTest04.cpp
@@ -25,7 +25,7 @@ stencil Test {
 
   Do {
     vertical_region(k_start, k_end) {
-      tmp = field_a(i + 1) + field_b(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_1, field_b:field_b_1
+      tmp = field_a(i + 1) + field_b(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_0, field_b:field_b_0
       field_a = tmp;
       field_b = tmp;
     }

--- a/test/integration-test/PassFieldVersioning/VersioingTest05.cpp
+++ b/test/integration-test/PassFieldVersioning/VersioingTest05.cpp
@@ -25,7 +25,7 @@ stencil Test {
 
   Do {
     vertical_region(k_start, k_end) {
-      tmp1 = field_a(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_1
+      tmp1 = field_a(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_0
       tmp2 = tmp1;
       field_a = tmp2;
     }

--- a/test/integration-test/PassFieldVersioning/VersioingTest06.cpp
+++ b/test/integration-test/PassFieldVersioning/VersioingTest06.cpp
@@ -25,10 +25,10 @@ stencil Test {
 
   Do {
     vertical_region(k_start, k_end) {
-      tmp = field(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_1:field_2
-      field = tmp;        // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% tmp:tmp_1
+      tmp = field(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_0:field_1
+      field = tmp;        // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% tmp:tmp_0
 
-      tmp = field(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field:field_1
+      tmp = field(i + 1); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field:field_0
       field = tmp;
     }
   }

--- a/test/integration-test/PassFieldVersioning/VersioningTest07.cpp
+++ b/test/integration-test/PassFieldVersioning/VersioningTest07.cpp
@@ -33,7 +33,7 @@ stencil Test {
 
   Do {
     vertical_region(k_start, k_end) {
-      field_a = TestFunction(field_a); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_1
+      field_a = TestFunction(field_a); // EXPECTED: PASS: PassFieldVersioning: Test: rename:%line% field_a:field_a_0
     }
   }
 };


### PR DESCRIPTION
## Technical Description

Field versioning will be 0-based, hence reference files need to be updated

## Dependencies

This is built for https://github.com/MeteoSwiss-APN/dawn/pull/187