### PR TITLE
Stdout

### DIFF
--- a/src/gtclang/Driver/Options.inc
+++ b/src/gtclang/Driver/Options.inc
@@ -50,5 +50,6 @@ OPT(bool, ClangFormat, true, "clang-format", "", "Run clang-format on the genera
 OPT(bool, ReportPassPreprocessor, false, "report-pass-preprocessor", "", 
     "Print each line of the preprocessed source prepended by the line number (comments and indentation are removed)", "", false, true)
 OPT(bool, Serialized, false, "loaded-serialized", "", "is the passed file serialized data", "", false, true)
+OPT(bool, WriteToStdOut, false, "write-stdout", "", "write to std out", "", false, true)
 
 // clang-format on

--- a/src/gtclang/Driver/Options.inc
+++ b/src/gtclang/Driver/Options.inc
@@ -50,6 +50,5 @@ OPT(bool, ClangFormat, true, "clang-format", "", "Run clang-format on the genera
 OPT(bool, ReportPassPreprocessor, false, "report-pass-preprocessor", "", 
     "Print each line of the preprocessed source prepended by the line number (comments and indentation are removed)", "", false, true)
 OPT(bool, Serialized, false, "loaded-serialized", "", "is the passed file serialized data", "", false, true)
-OPT(bool, WriteToStdOut, false, "write-stdout", "", "write to std out", "", false, true)
 
 // clang-format on

--- a/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -277,7 +277,7 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
   std::shared_ptr<llvm::raw_ostream> ost;
   std::error_code ec;
   llvm::sys::fs::OpenFlags flags = llvm::sys::fs::OpenFlags::F_RW;
-  if(context_->getOptions().WriteToStdOut) {
+  if(context_->getOptions().OutputFile.empty()) {
     ost = std::make_shared<llvm::raw_os_ostream>(std::cout);
   } else {
     ost = std::make_shared<llvm::raw_fd_ostream>(generatedFilename, ec, flags);

--- a/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -273,24 +273,39 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
     code = clangformat.format(code);
   }
 
-  // Write file to disk
-  DAWN_LOG(INFO) << "Writing file to disk... ";
-  std::error_code ec;
-  llvm::sys::fs::OpenFlags flags = llvm::sys::fs::OpenFlags::F_RW;
-  llvm::raw_fd_ostream fout(generatedFilename, ec, flags);
+  if(context_->getOptions().WriteToStdOut) {
+    // Write file to std::cout
+    DAWN_LOG(INFO) << "Writing file to output... ";
+    // Print a header
+    std::cout << dawn::format("// gtclang (%s)\n// based on LLVM/Clang (%s), Dawn (%s)\n",
+                              GTCLANG_FULL_VERSION_STR, LLVM_VERSION_STRING, DAWN_VERSION_STR);
+    std::cout << "// Generated on " << currentDateTime() << "\n\n";
 
-  // Print a header
-  fout << dawn::format("// gtclang (%s)\n// based on LLVM/Clang (%s), Dawn (%s)\n",
-                       GTCLANG_FULL_VERSION_STR, LLVM_VERSION_STRING, DAWN_VERSION_STR);
-  fout << "// Generated on " << currentDateTime() << "\n\n";
+    // Add the macro definitions
+    for(const auto& macroDefine : DawnTranslationUnit->getPPDefines())
+      std::cout << macroDefine << "\n";
 
-  // Add the macro definitions
-  for(const auto& macroDefine : DawnTranslationUnit->getPPDefines())
-    fout << macroDefine << "\n";
+    std::cout.write(code.data(), code.size());
+  } else {
+    // Write file to disk
+    DAWN_LOG(INFO) << "Writing file to disk... ";
+    std::error_code ec;
+    llvm::sys::fs::OpenFlags flags = llvm::sys::fs::OpenFlags::F_RW;
+    llvm::raw_fd_ostream fout(generatedFilename, ec, flags);
 
-  fout.write(code.data(), code.size());
-  if(ec.value())
-    context_->getDiagnostics().report(Diagnostics::err_fs_error) << ec.message();
+    // Print a header
+    fout << dawn::format("// gtclang (%s)\n// based on LLVM/Clang (%s), Dawn (%s)\n",
+                         GTCLANG_FULL_VERSION_STR, LLVM_VERSION_STRING, DAWN_VERSION_STR);
+    fout << "// Generated on " << currentDateTime() << "\n\n";
+
+    // Add the macro definitions
+    for(const auto& macroDefine : DawnTranslationUnit->getPPDefines())
+      fout << macroDefine << "\n";
+
+    fout.write(code.data(), code.size());
+    if(ec.value())
+      context_->getDiagnostics().report(Diagnostics::err_fs_error) << ec.message();
+  }
 }
 
 } // namespace gtclang

--- a/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -283,7 +283,7 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
     ost = std::make_shared<llvm::raw_fd_ostream>(generatedFilename, ec, flags);
   }
 
-  // Write file to disk
+  // Write file to specified output
   DAWN_LOG(INFO) << "Writing file to output... ";
 
   // Print a header


### PR DESCRIPTION
## Technical Description

This allows for std::cout as the output rather than a generated file which make the use of containers much simpler.

#### Resolves

The issue that deployment for the ICON-OCEAN team did not work and provides a simple alternative

#### Example

```
docker run -v  `pwd`:/data gtclang/gtclang /data/test.cpp  > out.cpp
```

## Dependencies

This PR has no dependencies