### PR TITLE
fix dependency propagation

### DIFF
--- a/src/gtclang/Frontend/CMakeLists.txt
+++ b/src/gtclang/Frontend/CMakeLists.txt
@@ -44,7 +44,6 @@ yoda_add_library(
   OBJECT
 )
 
-target_include_directories(GTClangFrontendObjects PRIVATE
-  $<TARGET_PROPERTY:Dawn::DawnShared,INTERFACE_INCLUDE_DIRECTORIES>
-)
+target_include_directories(GTClangFrontendObjects SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
+
 


### PR DESCRIPTION
## Technical Description

Since dawn cannot propagate the dependency to boost anymore we specify it here in gtclang for the required targets

#### Resolves / Enhances

The dependency propagation of boost with dawn broke with https://github.com/MeteoSwiss-APN/dawn/commit/1d9b06f115d4a45f5d5d369b980b3ff151a9708e


## Testing

Since we cannot test this automatically, the reviewer should clone gtlcang and try to build it locally.


