### PR TITLE
Change parsing tests to not write files to std-out

### DIFF
--- a/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/src/gtclang/Unittest/ParsingComparison.cpp
@@ -194,7 +194,7 @@ CompareResult ParsingComparison::compare(const ParsedString& ps,
       dawn::format("TestStencil_%i.cpp", UnittestEnvironment::getSingleton().getUniqueID());
   FileWriter writer(localPath, fileName);
   writer.addParsedString(ps);
-  auto out = GTClang::run({writer.getFileName()},
+  auto out = GTClang::run({writer.getFileName(), "-fno-codegen"},
                           UnittestEnvironment::getSingleton().getFlagManager().getDefaultFlags());
   if(!out.first) {
     return CompareResult{"could not parse file " + writer.getFileName(), false};


### PR DESCRIPTION
## Technical Description

Removes output files from the parsing unittests, The tests still compare the SIR's but are no longer polluting the output with files / text.

#### Resolves / Enhances

With the change to how output is handled, the parsing tests were very verbose since they printed the full generated file to std::out and made inspection of the tests harder. This is resolved here
 
#### Example

`ctest -V`

## Dependencies

This PR is independent

