### PR TITLE
move to gcc 5.4

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -90,7 +90,7 @@ yoda_find_package(
   REQUIRED_VARS dawn_DIR
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
-    GIT_REPOSITORY "git@github.com:cosunae/dawn.git"
+    GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
     GIT_TAG "kesch_gcc5.4" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -91,7 +91,7 @@ yoda_find_package(
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
     GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
-    GIT_TAG "kesch_gcc5.4" 
+    GIT_TAG "master" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}
 )

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -90,8 +90,8 @@ yoda_find_package(
   REQUIRED_VARS dawn_DIR
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
-    GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
-    GIT_TAG "master" 
+    GIT_REPOSITORY "git@github.com:cosunae/dawn.git"
+    GIT_TAG "kesch_gcc5.4" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}
 )

--- a/scripts/jenkins/env_kesch.sh
+++ b/scripts/jenkins/env_kesch.sh
@@ -4,14 +4,12 @@ module load PE/17.06
 module load git
 module load /users/jenkins/easybuild/kesch/modules/all/cmake/3.12.4
 module load python/3.6.2-gmvolf-17.02
-module unload gcc
-module load gcc/6.1.0
 module load cudatoolkit/8.0.61
 
 export CXX=`which g++`
 export CC=`which gcc`
 export BOOST_DIR=/project/c14/install/kesch/boost/boost_1_67_0/
-export LLVM_DIR=/project/c14/install/kesch/clang/600/
+export LLVM_DIR=/project/c14/install/kesch/clang/llvmorg-6.0.1
 
 export SLURM_RESOURCES=('--gres=gpu:1')
 export SLURM_PARTITION="debug"


### PR DESCRIPTION
Using the latest gcc (6) was bad idea, since many other software is built (like clang) using the default 5.4
Also updating the clang installation in kesch