### PR TITLE
Update clang format

### DIFF
--- a/cmake/Addclang-format.cmake
+++ b/cmake/Addclang-format.cmake
@@ -16,7 +16,7 @@
 
 include(yodaExportPackage)
 
-find_package(clang-format)
+find_package(clang-format EXACT 6.0)
 
 yoda_export_package(
   NAME clang-format

--- a/src/gtclang/Driver/CompilerInstance.cpp
+++ b/src/gtclang/Driver/CompilerInstance.cpp
@@ -45,7 +45,7 @@ std::string getExecutablePath(const char* argv0) {
   return llvm::sys::fs::getMainExecutable(argv0, main_addr);
 }
 
-} // namespace anonymous
+} // namespace
 
 clang::CompilerInstance* createCompilerInstance(llvm::SmallVectorImpl<const char*>& args) {
   using namespace clang;

--- a/src/gtclang/Frontend/ClangASTExprResolver.cpp
+++ b/src/gtclang/Frontend/ClangASTExprResolver.cpp
@@ -596,8 +596,9 @@ public:
   /// stencil function is a field, which will be resolved elsewhere
   std::shared_ptr<dawn::StencilFunArgExpr>
   makeStencilFunArgExpr(const dawn::SourceLocation& loc) const {
-    return isStorage_ ? nullptr : std::make_shared<dawn::StencilFunArgExpr>(direction_, offset_,
-                                                                            argumentIndex_, loc);
+    return isStorage_ ? nullptr
+                      : std::make_shared<dawn::StencilFunArgExpr>(direction_, offset_,
+                                                                  argumentIndex_, loc);
   }
 
 private:
@@ -726,9 +727,10 @@ std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveDecl(clang::VarDecl* de
   auto it = parser_->getCurrentParserRecord()->CurrentArgDeclMap.find(varname);
   if(it != argDeclMap.end()) {
     reportDiagnostic(decl->getLocStart(), Diagnostics::err_do_method_var_shadowing)
-        << varname << (parser_->getCurrentParserRecord()->CurrentKind == StencilParser::SK_Stencil
-                           ? "stencil"
-                           : "stencil function");
+        << varname
+        << (parser_->getCurrentParserRecord()->CurrentKind == StencilParser::SK_Stencil
+                ? "stencil"
+                : "stencil function");
     reportDiagnostic(it->second.Decl->getLocation(), Diagnostics::note_previous_definition);
   }
 

--- a/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -42,7 +42,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_os_ostream.h"

--- a/src/gtclang/Support/ASTUtils.cpp
+++ b/src/gtclang/Support/ASTUtils.cpp
@@ -25,4 +25,4 @@ std::string getClassNameFromConstructExpr(clang::CXXConstructExpr* expr) {
   clang::CXXRecordDecl* recDecl = expr->getConstructor()->getParent();
   return recDecl->getNameAsString();
 }
-}
+} // namespace gtclang

--- a/src/gtclang/Support/ASTUtils.h
+++ b/src/gtclang/Support/ASTUtils.h
@@ -41,4 +41,4 @@ skipAllImplicitNodes(T* e) {
     e = e->IgnoreImplicit();
   return e;
 }
-}
+} // namespace gtclang


### PR DESCRIPTION
## Technical Description

Update to clang-format 6.0 and a reformatting of the repo

#### Resolves / Enhances

Formatting inconsistencies that cropped up.

## Dependencies

This PR is independent, but the same update happens in dawn and clang-gridtools https://github.com/MeteoSwiss-APN/dawn/pull/214 and https://github.com/MeteoSwiss-APN/clang-gridtools/pull/120/files

## Upgrade locally
```
sudo apt-get install clang-format-6.0
sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 1
```


