### PR TITLE
Update namespace prefixes of AST classes

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -90,8 +90,8 @@ yoda_find_package(
   REQUIRED_VARS dawn_DIR
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
-    GIT_REPOSITORY "git@github.com:Stagno/dawn.git"
-    GIT_TAG "refactor_AST" 
+    GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
+    GIT_TAG "master" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}
 )

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -90,8 +90,8 @@ yoda_find_package(
   REQUIRED_VARS dawn_DIR
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
-    GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
-    GIT_TAG "master" 
+    GIT_REPOSITORY "git@github.com:Stagno/dawn.git"
+    GIT_TAG "refactor_AST" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}
 )

--- a/src/gtclang/Frontend/ClangASTExprResolver.cpp
+++ b/src/gtclang/Frontend/ClangASTExprResolver.cpp
@@ -53,7 +53,7 @@ class FunctionResolver {
     std::shared_ptr<dawn::sir::StencilFunction> SIRStencilFunction = nullptr;
 
     /// AST node of the C++ or stencil function i.e the result of the parsing
-    std::shared_ptr<dawn::FunCallExpr> DAWNFunCallExpr = nullptr;
+    std::shared_ptr<dawn::sir::FunCallExpr> DAWNFunCallExpr = nullptr;
 
     /// Clang AST node of the call to the stencil function (e.g `avg(i+1, u)`)
     clang::CXXConstructExpr* ClangCXXConstructExpr = nullptr;
@@ -90,7 +90,7 @@ public:
     std::string callee = getClassNameFromConstructExpr(expr);
 
     scope_.top()->DAWNFunCallExpr =
-        std::make_shared<dawn::StencilFunCallExpr>(callee, resolver_->getSourceLocation(expr));
+        std::make_shared<dawn::sir::StencilFunCallExpr>(callee, resolver_->getSourceLocation(expr));
     scope_.top()->ClangCXXConstructExpr = expr;
 
     auto stencilFunPair = resolver_->getParser()->getStencilFunctionByName(callee);
@@ -115,7 +115,7 @@ public:
     scope_.top()->Kind = FK_CXXFunction;
 
     DAWN_ASSERT_MSG(expr->getDirectCallee(), "only C-function calls are supported");
-    scope_.top()->DAWNFunCallExpr = std::make_shared<dawn::FunCallExpr>(
+    scope_.top()->DAWNFunCallExpr = std::make_shared<dawn::sir::FunCallExpr>(
         expr->getDirectCallee()->getQualifiedNameAsString(), resolver_->getSourceLocation(expr));
 
     return true;
@@ -137,8 +137,8 @@ public:
   void skipNextArguments(int N) { scope_.top()->ArgumentsToSkip += N; }
 
   /// @brief Add an argument to the current stencil function
-  std::shared_ptr<dawn::Expr> addArgument(clang::Expr* expr,
-                                          const std::shared_ptr<dawn::Expr>& arg) {
+  std::shared_ptr<dawn::sir::Expr> addArgument(clang::Expr* expr,
+                                          const std::shared_ptr<dawn::sir::Expr>& arg) {
     // ignore implicit nodes
     expr = skipAllImplicitNodes(expr);
 
@@ -201,7 +201,7 @@ public:
   }
 
   /// @brief Get the StencilFunCallExpr and pop the current stencil function
-  std::shared_ptr<dawn::FunCallExpr> pop() {
+  std::shared_ptr<dawn::sir::FunCallExpr> pop() {
     auto expr = scope_.top()->DAWNFunCallExpr;
     scope_.pop();
     return expr;
@@ -256,7 +256,7 @@ private:
   }
 
   /// @brief Check if types of arguments match
-  void checkTypeOfArgumentMatches(clang::Expr* expr, dawn::Expr* parsedArg) {
+  void checkTypeOfArgumentMatches(clang::Expr* expr, dawn::sir::Expr* parsedArg) {
     // ignore implicit nodes
     expr = skipAllImplicitNodes(expr);
 
@@ -303,11 +303,11 @@ private:
   };
 
   /// @brief Convert an AST stencil function argument to the matching index in `TypeStr`
-  static ArgumentIndex getIndexFromASTArg(dawn::Expr* expr) {
-    if(dawn::isa<dawn::FieldAccessExpr>(expr) || dawn::isa<dawn::StencilFunCallExpr>(expr))
+  static ArgumentIndex getIndexFromASTArg(dawn::sir::Expr* expr) {
+    if(dawn::isa<dawn::sir::FieldAccessExpr>(expr) || dawn::isa<dawn::sir::StencilFunCallExpr>(expr))
       return AK_Field;
 
-    dawn::StencilFunArgExpr* arg = dawn::dyn_cast<dawn::StencilFunArgExpr>(expr);
+    dawn::sir::StencilFunArgExpr* arg = dawn::dyn_cast<dawn::sir::StencilFunArgExpr>(expr);
     if(!arg)
       return AK_Unknown;
 
@@ -366,9 +366,9 @@ public:
   /// @}
 
   /// @brief Assemble FieldAccessExpr
-  std::shared_ptr<dawn::FieldAccessExpr>
+  std::shared_ptr<dawn::sir::FieldAccessExpr>
   makeFieldAccessExpr(const dawn::SourceLocation& loc) const {
-    return std::make_shared<dawn::FieldAccessExpr>(name_, offset_, argumentMap_, argumentOffset_,
+    return std::make_shared<dawn::sir::FieldAccessExpr>(name_, offset_, argumentMap_, argumentOffset_,
                                                    negateOffset_, loc);
   }
 
@@ -594,10 +594,10 @@ public:
   ///
   /// This may return a nullptr if parsing failed. This can happen if the argument to the
   /// stencil function is a field, which will be resolved elsewhere
-  std::shared_ptr<dawn::StencilFunArgExpr>
+  std::shared_ptr<dawn::sir::StencilFunArgExpr>
   makeStencilFunArgExpr(const dawn::SourceLocation& loc) const {
     return isStorage_ ? nullptr
-                      : std::make_shared<dawn::StencilFunArgExpr>(direction_, offset_,
+                      : std::make_shared<dawn::sir::StencilFunArgExpr>(direction_, offset_,
                                                                   argumentIndex_, loc);
   }
 
@@ -628,7 +628,7 @@ ClangASTExprResolver::ClangASTExprResolver(GTClangContext* context, StencilParse
     : context_(context), parser_(parser),
       functionResolver_(std::make_shared<FunctionResolver>(this)) {}
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::BinaryOperator* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::BinaryOperator* expr) {
   resetInternals();
 
   switch(clang::BinaryOperator::getOverloadedOperator(expr->getOpcode())) {
@@ -637,10 +637,11 @@ std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::BinaryOpera
   case clang::OO_SlashEqual:
   case clang::OO_PlusEqual:
   case clang::OO_MinusEqual:
-    return std::make_shared<dawn::ExprStmt>(resolveAssignmentOp(expr), getSourceLocation(expr));
+    return std::make_shared<dawn::sir::ExprStmt>(resolveAssignmentOp(expr),
+                                                 getSourceLocation(expr));
   default:
-    return std::make_shared<dawn::ExprStmt>(
-        std::make_shared<dawn::BinaryOperator>(
+    return std::make_shared<dawn::sir::ExprStmt>(
+        std::make_shared<dawn::sir::BinaryOperator>(
             resolve(expr->getLHS()),
             clang::getOperatorSpelling(
                 clang::BinaryOperator::getOverloadedOperator(expr->getOpcode())),
@@ -649,7 +650,7 @@ std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::BinaryOpera
   }
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXOperatorCallExpr* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXOperatorCallExpr* expr) {
   resetInternals();
 
   switch(expr->getOperator()) {
@@ -658,53 +659,54 @@ std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXOperator
   case clang::OO_SlashEqual:
   case clang::OO_PlusEqual:
   case clang::OO_MinusEqual:
-    return std::make_shared<dawn::ExprStmt>(resolveAssignmentOp(expr), getSourceLocation(expr));
+    return std::make_shared<dawn::sir::ExprStmt>(resolveAssignmentOp(expr),
+                                                 getSourceLocation(expr));
   default:
     llvm_unreachable("invalid operator call expr");
   }
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXConstructExpr* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXConstructExpr* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXFunctionalCastExpr* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXFunctionalCastExpr* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::FloatingLiteral* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::FloatingLiteral* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::IntegerLiteral* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::IntegerLiteral* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXBoolLiteralExpr* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::CXXBoolLiteralExpr* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::DeclRefExpr* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::DeclRefExpr* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::UnaryOperator* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::UnaryOperator* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveExpr(clang::MemberExpr* expr) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveExpr(clang::MemberExpr* expr) {
   resetInternals();
-  return std::make_shared<dawn::ExprStmt>(resolve(expr), getSourceLocation(expr));
+  return std::make_shared<dawn::sir::ExprStmt>(resolve(expr), getSourceLocation(expr));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveDecl(clang::VarDecl* decl) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveDecl(clang::VarDecl* decl) {
   resetInternals();
   using namespace clang;
 
@@ -782,7 +784,7 @@ std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveDecl(clang::VarDecl* de
   }
 
   // Resolve initializer list
-  std::vector<std::shared_ptr<dawn::Expr>> initList;
+  std::vector<std::shared_ptr<dawn::sir::Expr>> initList;
   if(decl->hasInit()) {
     if(InitListExpr* varInitList = dyn_cast<InitListExpr>(decl->getInit())) {
       for(Expr* init : varInitList->inits())
@@ -791,13 +793,14 @@ std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveDecl(clang::VarDecl* de
       initList.push_back(resolve(decl->getInit()));
   }
 
-  return std::make_shared<dawn::VarDeclStmt>(DAWNType, varname, dimension, "=", std::move(initList),
-                                             getSourceLocation(decl));
+  return std::make_shared<dawn::sir::VarDeclStmt>(DAWNType, varname, dimension, "=",
+                                                  std::move(initList), getSourceLocation(decl));
 }
 
-std::shared_ptr<dawn::Stmt> ClangASTExprResolver::resolveStmt(clang::ReturnStmt* stmt) {
+std::shared_ptr<dawn::sir::Stmt> ClangASTExprResolver::resolveStmt(clang::ReturnStmt* stmt) {
   resetInternals();
-  return std::make_shared<dawn::ReturnStmt>(resolve(stmt->getRetValue()), getSourceLocation(stmt));
+  return std::make_shared<dawn::sir::ReturnStmt>(resolve(stmt->getRetValue()),
+                                                 getSourceLocation(stmt));
 }
 
 dawn::SourceLocation ClangASTExprResolver::getSourceLocation(clang::Stmt* stmt) const {
@@ -813,7 +816,7 @@ dawn::SourceLocation ClangASTExprResolver::getSourceLocation(clang::Decl* decl) 
 //===------------------------------------------------------------------------------------------===//
 //     Internal expression resolver
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::Expr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::Expr* expr) {
   using namespace clang;
   // ignore implicit nodes
   expr = skipAllImplicitNodes(expr);
@@ -861,11 +864,11 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::Expr* expr) {
   llvm_unreachable("invalid expr");
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::ArraySubscriptExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::ArraySubscriptExpr* expr) {
   // Resolve the variable
   auto DAWNExpr = resolve(expr->getBase());
 
-  auto DAWNVarAccessExpr = dawn::dyn_cast<dawn::VarAccessExpr>(DAWNExpr.get());
+  auto DAWNVarAccessExpr = dawn::dyn_cast<dawn::sir::VarAccessExpr>(DAWNExpr.get());
   DAWN_ASSERT(DAWNVarAccessExpr);
 
   // Resolve the index
@@ -873,11 +876,11 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::ArraySubscriptE
   return DAWNExpr;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::BinaryOperator* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::BinaryOperator* expr) {
   if(functionResolver_->isActive())
     functionResolver_->skipNextArguments(2);
 
-  auto binary = std::make_shared<dawn::BinaryOperator>(
+  auto binary = std::make_shared<dawn::sir::BinaryOperator>(
       resolve(expr->getLHS()),
       clang::getOperatorSpelling(clang::BinaryOperator::getOverloadedOperator(expr->getOpcode())),
       resolve(expr->getRHS()), getSourceLocation(expr));
@@ -892,7 +895,7 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::BinaryOperator*
   return binary;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CallExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CallExpr* expr) {
   bool isNestedFunction = functionResolver_->isActive();
   functionResolver_->push(expr);
 
@@ -906,13 +909,13 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CallExpr* expr)
   return function;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CStyleCastExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CStyleCastExpr* expr) {
   currentCStyleCastExpr_ = expr;
   return resolve(expr->getSubExpr());
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXBoolLiteralExpr* expr) {
-  auto booleanLiteral = std::make_shared<dawn::LiteralAccessExpr>(
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CXXBoolLiteralExpr* expr) {
+  auto booleanLiteral = std::make_shared<dawn::sir::LiteralAccessExpr>(
       expr->getValue() ? "true" : "false", resolveBuiltinType(expr), getSourceLocation(expr));
 
   if(functionResolver_->isActive())
@@ -922,7 +925,7 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXBoolLiteralE
   return booleanLiteral;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXOperatorCallExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CXXOperatorCallExpr* expr) {
   if(expr->getOperator() == clang::OO_Call) {
 
     // This should be a call to a storage with offset (e.g `u(i, j, k)`)
@@ -948,7 +951,7 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXOperatorCall
   llvm_unreachable("invalid operator");
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXConstructExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CXXConstructExpr* expr) {
   if(StorageResolver::isaStorage(getClassNameFromConstructExpr(expr)) && expr->getNumArgs() == 1) {
     // This is an access to a storage e.g `u = ...`
     return resolve(expr->getArg(0));
@@ -986,8 +989,8 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXConstructExp
     functionResolver_->checkNumOfArgumentsMatch();
 
     // If we parse a nested stencil function, we need to register it as an argument
-    std::shared_ptr<dawn::StencilFunCallExpr> stencilFunctionFun =
-        std::static_pointer_cast<dawn::StencilFunCallExpr>(functionResolver_->pop());
+    std::shared_ptr<dawn::sir::StencilFunCallExpr> stencilFunctionFun =
+        std::static_pointer_cast<dawn::sir::StencilFunCallExpr>(functionResolver_->pop());
     if(isNestedFunction)
       functionResolver_->addArgument(expr, stencilFunctionFun);
 
@@ -995,7 +998,7 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXConstructExp
   }
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXMemberCallExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CXXMemberCallExpr* expr) {
   std::string methodName = expr->getMethodDecl()->getNameInfo().getName().getAsString();
   if(methodName == "operator double") {
     // This covers 2 cases:
@@ -1014,16 +1017,16 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXMemberCallEx
   llvm_unreachable("invalid CXXMemberCallExpr");
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::CXXFunctionalCastExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::CXXFunctionalCastExpr* expr) {
   return resolve(expr->getSubExpr());
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::ConditionalOperator* expr) {
-  return std::make_shared<dawn::TernaryOperator>(resolve(expr->getCond()), resolve(expr->getLHS()),
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::ConditionalOperator* expr) {
+  return std::make_shared<dawn::sir::TernaryOperator>(resolve(expr->getCond()), resolve(expr->getLHS()),
                                                  resolve(expr->getRHS()));
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::DeclRefExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::DeclRefExpr* expr) {
   // Check we don't reference non-local variables (this will not end well in CUDA code)
   if(clang::VarDecl* varDecl = clang::dyn_cast<clang::VarDecl>(expr->getDecl())) {
     if(!varDecl->isLocalVarDecl()) {
@@ -1035,7 +1038,7 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::DeclRefExpr* ex
   }
 
   // Access to a locally declared variable
-  auto var = std::make_shared<dawn::VarAccessExpr>(expr->getNameInfo().getAsString(), nullptr,
+  auto var = std::make_shared<dawn::sir::VarAccessExpr>(expr->getNameInfo().getAsString(), nullptr,
                                                    getSourceLocation(expr));
 
   if(functionResolver_->isActive())
@@ -1043,11 +1046,11 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::DeclRefExpr* ex
   return var;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::FloatingLiteral* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::FloatingLiteral* expr) {
   llvm::SmallVector<char, 10> valueVec;
   expr->getValue().toString(valueVec);
   auto floatLiteral =
-      std::make_shared<dawn::LiteralAccessExpr>(std::string(valueVec.data(), valueVec.size()),
+      std::make_shared<dawn::sir::LiteralAccessExpr>(std::string(valueVec.data(), valueVec.size()),
                                                 resolveBuiltinType(expr), getSourceLocation(expr));
 
   if(functionResolver_->isActive())
@@ -1057,8 +1060,8 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::FloatingLiteral
   return floatLiteral;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::IntegerLiteral* expr) {
-  auto integerLiteral = std::make_shared<dawn::LiteralAccessExpr>(
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::IntegerLiteral* expr) {
+  auto integerLiteral = std::make_shared<dawn::sir::LiteralAccessExpr>(
       expr->getValue().toString(10, true), resolveBuiltinType(expr), getSourceLocation(expr));
 
   if(functionResolver_->isActive())
@@ -1068,12 +1071,12 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::IntegerLiteral*
   return integerLiteral;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::MemberExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::MemberExpr* expr) {
   llvm::StringRef baseIdentifier = expr->getBase()->getType().getBaseTypeIdentifier()->getName();
 
   if(baseIdentifier == "globals") {
     // Access to a global variable
-    auto var = std::make_shared<dawn::VarAccessExpr>(expr->getMemberNameInfo().getAsString(),
+    auto var = std::make_shared<dawn::sir::VarAccessExpr>(expr->getMemberNameInfo().getAsString(),
                                                      nullptr, getSourceLocation(expr));
     var->setIsExternal(true);
     DAWN_ASSERT_MSG(parser_->isGlobalVariable(var->getName()),
@@ -1109,15 +1112,15 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::MemberExpr* exp
   return field;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::ParenExpr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::ParenExpr* expr) {
   return resolve(expr->getSubExpr());
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::UnaryOperator* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolve(clang::UnaryOperator* expr) {
   if(functionResolver_->isActive())
     functionResolver_->skipNextArguments(1);
 
-  auto unary = std::make_shared<dawn::UnaryOperator>(
+  auto unary = std::make_shared<dawn::sir::UnaryOperator>(
       resolve(expr->getSubExpr()),
       clang::getOperatorSpelling(clang::UnaryOperator::getOverloadedOperator(expr->getOpcode())),
       getSourceLocation(expr));
@@ -1132,14 +1135,14 @@ std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolve(clang::UnaryOperator* 
   return unary;
 }
 
-std::shared_ptr<dawn::Expr> ClangASTExprResolver::resolveAssignmentOp(clang::Expr* expr) {
+std::shared_ptr<dawn::sir::Expr> ClangASTExprResolver::resolveAssignmentOp(clang::Expr* expr) {
   if(clang::CXXOperatorCallExpr* e = clang::dyn_cast<clang::CXXOperatorCallExpr>(expr)) {
     DAWN_ASSERT(e->getNumArgs() == 2);
-    return std::make_shared<dawn::AssignmentExpr>(resolve(e->getArg(0)), resolve(e->getArg(1)),
+    return std::make_shared<dawn::sir::AssignmentExpr>(resolve(e->getArg(0)), resolve(e->getArg(1)),
                                                   clang::getOperatorSpelling(e->getOperator()),
                                                   getSourceLocation(e));
   } else if(clang::BinaryOperator* e = clang::dyn_cast<clang::BinaryOperator>(expr)) {
-    return std::make_shared<dawn::AssignmentExpr>(
+    return std::make_shared<dawn::sir::AssignmentExpr>(
         resolve(e->getLHS()), resolve(e->getRHS()),
         clang::getOperatorSpelling(clang::BinaryOperator::getOverloadedOperator(e->getOpcode())),
         getSourceLocation(e));

--- a/src/gtclang/Frontend/ClangASTExprResolver.h
+++ b/src/gtclang/Frontend/ClangASTExprResolver.h
@@ -44,39 +44,39 @@ public:
   ClangASTExprResolver(GTClangContext* context, StencilParser* parser);
 
   /// @brief Parse `LHS = ...` where LHS is a reference to a variable declaration
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::BinaryOperator* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::BinaryOperator* expr);
 
   /// @brief Parse `LHS = ...` where LHS is a storage
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::CXXOperatorCallExpr* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::CXXOperatorCallExpr* expr);
 
   /// @brief Parse call to a stencil function (e.g `avg(u)`)
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::CXXConstructExpr* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::CXXConstructExpr* expr);
 
   /// @brief Parse call to a stencil function (e.g `avg(i+1)`)
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::CXXFunctionalCastExpr* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::CXXFunctionalCastExpr* expr);
 
   /// @brief Parse a single literal
   /// @{
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::FloatingLiteral* expr);
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::IntegerLiteral* expr);
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::CXXBoolLiteralExpr* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::FloatingLiteral* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::IntegerLiteral* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::CXXBoolLiteralExpr* expr);
   /// @}
 
   /// @brief Parse `var;` where var is an unused result
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::DeclRefExpr* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::DeclRefExpr* expr);
 
   /// @brief Parse `var` where var is a member access needed for parsing of `if(var) { ... }` where
   /// var is a global variable
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::MemberExpr* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::MemberExpr* expr);
 
   /// @brief Parse `+/-var;` where var is an unused result
-  std::shared_ptr<dawn::Stmt> resolveExpr(clang::UnaryOperator* expr);
+  std::shared_ptr<dawn::sir::Stmt> resolveExpr(clang::UnaryOperator* expr);
 
   /// @brief Parse `return ...`
-  std::shared_ptr<dawn::Stmt> resolveStmt(clang::ReturnStmt* stmt);
+  std::shared_ptr<dawn::sir::Stmt> resolveStmt(clang::ReturnStmt* stmt);
 
   /// @brief Parse `LHS = ...` where LHS is a variable declaration
-  std::shared_ptr<dawn::Stmt> resolveDecl(clang::VarDecl* decl);
+  std::shared_ptr<dawn::sir::Stmt> resolveDecl(clang::VarDecl* decl);
 
   /// @brief Get the stencil parser
   const StencilParser* getParser() const { return parser_; }
@@ -96,25 +96,25 @@ private:
   //===----------------------------------------------------------------------------------------===//
   //     Internal expression resolver
   //===----------------------------------------------------------------------------------------===//
-  std::shared_ptr<dawn::Expr> resolve(clang::Expr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::ArraySubscriptExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::BinaryOperator* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CallExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CStyleCastExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CXXBoolLiteralExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CXXOperatorCallExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CXXConstructExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CXXMemberCallExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::CXXFunctionalCastExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::ConditionalOperator* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::DeclRefExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::FloatingLiteral* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::IntegerLiteral* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::MemberExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::ParenExpr* expr);
-  std::shared_ptr<dawn::Expr> resolve(clang::UnaryOperator* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::Expr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::ArraySubscriptExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::BinaryOperator* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CallExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CStyleCastExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CXXBoolLiteralExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CXXOperatorCallExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CXXConstructExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CXXMemberCallExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::CXXFunctionalCastExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::ConditionalOperator* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::DeclRefExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::FloatingLiteral* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::IntegerLiteral* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::MemberExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::ParenExpr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolve(clang::UnaryOperator* expr);
 
-  std::shared_ptr<dawn::Expr> resolveAssignmentOp(clang::Expr* expr);
+  std::shared_ptr<dawn::sir::Expr> resolveAssignmentOp(clang::Expr* expr);
 
   dawn::BuiltinTypeID resolveBuiltinType(clang::Expr* expr);
 

--- a/src/gtclang/Frontend/ClangASTExprResolver.h
+++ b/src/gtclang/Frontend/ClangASTExprResolver.h
@@ -18,6 +18,7 @@
 #define GTCLANG_FRONTEND_CLANGASTEXPRRESOLVER_H
 
 #include "dawn/SIR/ASTFwd.h"
+#include "dawn/Support/Type.h"
 #include "gtclang/Frontend/Diagnostics.h"
 #include "clang/AST/ASTFwd.h"
 #include <memory>

--- a/src/gtclang/Frontend/ClangASTStmtResolver.cpp
+++ b/src/gtclang/Frontend/ClangASTStmtResolver.cpp
@@ -30,19 +30,19 @@ ClangASTStmtResolver::ClangASTStmtResolver(GTClangContext* context, StencilParse
 ClangASTStmtResolver::ClangASTStmtResolver(const std::shared_ptr<ClangASTExprResolver>& resolver)
     : clangASTExprResolver_(resolver), AstKind_(AK_Unknown) {}
 
-llvm::ArrayRef<std::shared_ptr<dawn::Stmt>> ClangASTStmtResolver::resolveStmt(clang::Stmt* stmt,
+llvm::ArrayRef<std::shared_ptr<dawn::sir::Stmt>> ClangASTStmtResolver::resolveStmt(clang::Stmt* stmt,
                                                                               ASTKind kind) {
   resetInternals();
   AstKind_ = kind;
   resolve(stmt);
-  return llvm::ArrayRef<std::shared_ptr<dawn::Stmt>>(statements_);
+  return llvm::ArrayRef<std::shared_ptr<dawn::sir::Stmt>>(statements_);
 }
 
-std::vector<std::shared_ptr<dawn::Stmt>>& ClangASTStmtResolver::getStatements() {
+std::vector<std::shared_ptr<dawn::sir::Stmt>>& ClangASTStmtResolver::getStatements() {
   return statements_;
 }
 
-const std::vector<std::shared_ptr<dawn::Stmt>>& ClangASTStmtResolver::getStatements() const {
+const std::vector<std::shared_ptr<dawn::sir::Stmt>>& ClangASTStmtResolver::getStatements() const {
   return statements_;
 }
 
@@ -142,7 +142,7 @@ void ClangASTStmtResolver::resolve(clang::ReturnStmt* stmt) {
 
 void ClangASTStmtResolver::resolve(clang::IfStmt* stmt) {
   using namespace clang;
-  std::shared_ptr<dawn::Stmt> condStmt = nullptr;
+  std::shared_ptr<dawn::sir::Stmt> condStmt = nullptr;
 
   // We currently don't support expression with variable decls in the condition
   if(stmt->getConditionVariable())
@@ -179,12 +179,12 @@ void ClangASTStmtResolver::resolve(clang::IfStmt* stmt) {
         << clangCond->getSourceRange();
   }
 
-  auto parseBody = [&](clang::Stmt* clangStmt) -> std::shared_ptr<dawn::BlockStmt> {
+  auto parseBody = [&](clang::Stmt* clangStmt) -> std::shared_ptr<dawn::sir::BlockStmt> {
     if(!clangStmt)
       return nullptr;
 
     auto blockStmt =
-        std::make_shared<dawn::BlockStmt>(clangASTExprResolver_->getSourceLocation(clangStmt));
+        std::make_shared<dawn::sir::BlockStmt>(clangASTExprResolver_->getSourceLocation(clangStmt));
     ClangASTStmtResolver resolver(clangASTExprResolver_);
 
     if(CompoundStmt* compound = dyn_cast<CompoundStmt>(clangStmt)) {
@@ -198,7 +198,7 @@ void ClangASTStmtResolver::resolve(clang::IfStmt* stmt) {
     return blockStmt;
   };
 
-  statements_.emplace_back(std::make_shared<dawn::IfStmt>(
+  statements_.emplace_back(std::make_shared<dawn::sir::IfStmt>(
       condStmt, parseBody(stmt->getThen()), parseBody(stmt->getElse()),
       clangASTExprResolver_->getSourceLocation(stmt)));
 }

--- a/src/gtclang/Frontend/ClangASTStmtResolver.h
+++ b/src/gtclang/Frontend/ClangASTStmtResolver.h
@@ -48,10 +48,10 @@ public:
   ClangASTStmtResolver(GTClangContext* context, StencilParser* parser);
 
   /// @brief Resolve a single statment into (possibly multiple) SIR Stmts
-  llvm::ArrayRef<std::shared_ptr<dawn::Stmt>> resolveStmt(clang::Stmt* stmt, ASTKind kind);
+  llvm::ArrayRef<std::shared_ptr<dawn::sir::Stmt>> resolveStmt(clang::Stmt* stmt, ASTKind kind);
 
-  std::vector<std::shared_ptr<dawn::Stmt>>& getStatements();
-  const std::vector<std::shared_ptr<dawn::Stmt>>& getStatements() const;
+  std::vector<std::shared_ptr<dawn::sir::Stmt>>& getStatements();
+  const std::vector<std::shared_ptr<dawn::sir::Stmt>>& getStatements() const;
 
 private:
   //===----------------------------------------------------------------------------------------===//
@@ -79,7 +79,7 @@ private:
   std::shared_ptr<ClangASTExprResolver> clangASTExprResolver_;
 
   // State variables
-  std::vector<std::shared_ptr<dawn::Stmt>> statements_;
+  std::vector<std::shared_ptr<dawn::sir::Stmt>> statements_;
   ASTKind AstKind_;
 };
 

--- a/src/gtclang/Frontend/StencilParser.cpp
+++ b/src/gtclang/Frontend/StencilParser.cpp
@@ -507,7 +507,7 @@ void StencilParser::parseStencilImpl(clang::CXXRecordDecl* recordDecl, const std
             .first->second.get();
     currentParserRecord_->CurrentStencil->Name = name;
     currentParserRecord_->CurrentStencil->Loc = getLocation(recordDecl);
-    currentParserRecord_->CurrentStencil->StencilDescAst = std::make_shared<dawn::AST>();
+    currentParserRecord_->CurrentStencil->StencilDescAst = std::make_shared<dawn::sir::AST>();
 
     // Parse the arguments
     for(FieldDecl* field : recordDecl->fields())
@@ -697,7 +697,7 @@ void StencilParser::parseStencilFunctionDoMethod(clang::CXXMethodDecl* DoMethod)
   if(DoMethod->hasBody()) {
 
     ClangASTStmtResolver stmtResolver(context_, this);
-    auto SIRBlockStmt = std::make_shared<dawn::BlockStmt>(getLocation(DoMethod->getBody()));
+    auto SIRBlockStmt = std::make_shared<dawn::sir::BlockStmt>(getLocation(DoMethod->getBody()));
 
     if(CompoundStmt* bodyStmt = dyn_cast<CompoundStmt>(DoMethod->getBody())) {
 
@@ -721,7 +721,7 @@ void StencilParser::parseStencilFunctionDoMethod(clang::CXXMethodDecl* DoMethod)
 
     // Assemble the stencil function
     currentParserRecord_->CurrentStencilFunction->Asts.emplace_back(
-        std::make_shared<dawn::AST>(std::move(SIRBlockStmt)));
+        std::make_shared<dawn::sir::AST>(std::move(SIRBlockStmt)));
 
     if(intervals)
       currentParserRecord_->CurrentStencilFunction->Intervals.emplace_back(std::move(intervals));
@@ -748,7 +748,7 @@ void StencilParser::parseStencilDoMethod(clang::CXXMethodDecl* DoMethod) {
 
       ClangASTStmtResolver stmtResolver(context_, this);
 
-      std::shared_ptr<dawn::AST>& stencilDescAst =
+      std::shared_ptr<dawn::sir::AST>& stencilDescAst =
           currentParserRecord_->CurrentStencil->StencilDescAst;
 
       // DoMethod is a CompoundStmt, start iterating
@@ -799,7 +799,7 @@ void StencilParser::parseStencilDoMethod(clang::CXXMethodDecl* DoMethod) {
   DAWN_LOG(INFO) << "Done parsing Do-Method";
 }
 
-std::shared_ptr<dawn::StencilCallDeclStmt>
+std::shared_ptr<dawn::sir::StencilCallDeclStmt>
 StencilParser::parseStencilCall(clang::CXXConstructExpr* stencilCall) {
 
   std::string callee = getClassNameFromConstructExpr(stencilCall);
@@ -890,10 +890,10 @@ StencilParser::parseStencilCall(clang::CXXConstructExpr* stencilCall) {
   SIRStencilCall->Args = std::move(fields);
 
   DAWN_LOG(INFO) << "Done parsing stencil call";
-  return std::make_shared<dawn::StencilCallDeclStmt>(SIRStencilCall, SIRStencilCall->Loc);
+  return std::make_shared<dawn::sir::StencilCallDeclStmt>(SIRStencilCall, SIRStencilCall->Loc);
 }
 
-std::shared_ptr<dawn::VerticalRegionDeclStmt>
+std::shared_ptr<dawn::sir::VerticalRegionDeclStmt>
 StencilParser::parseVerticalRegion(clang::CXXForRangeStmt* verticalRegion) {
   using namespace clang;
   using namespace llvm;
@@ -908,7 +908,7 @@ StencilParser::parseVerticalRegion(clang::CXXForRangeStmt* verticalRegion) {
   intervalResolver.resolve(verticalRegion);
 
   // Extract the Do-Method body (AST) from the loop body
-  auto SIRBlockStmt = std::make_shared<dawn::BlockStmt>(getLocation(verticalRegion));
+  auto SIRBlockStmt = std::make_shared<dawn::sir::BlockStmt>(getLocation(verticalRegion));
 
   // There is a difference between
   //
@@ -939,7 +939,7 @@ StencilParser::parseVerticalRegion(clang::CXXForRangeStmt* verticalRegion) {
   }
 
   // Assemble the vertical region and register it within the current Stencil
-  auto SIRAST = std::make_shared<dawn::AST>(std::move(SIRBlockStmt));
+  auto SIRAST = std::make_shared<dawn::sir::AST>(std::move(SIRBlockStmt));
 
   auto intervalPair = intervalResolver.getInterval();
 
@@ -947,10 +947,11 @@ StencilParser::parseVerticalRegion(clang::CXXForRangeStmt* verticalRegion) {
       SIRAST, intervalPair.first, intervalPair.second, getLocation(verticalRegion));
 
   DAWN_LOG(INFO) << "Done parsing vertical region";
-  return std::make_shared<dawn::VerticalRegionDeclStmt>(SIRVerticalRegion, SIRVerticalRegion->Loc);
+  return std::make_shared<dawn::sir::VerticalRegionDeclStmt>(SIRVerticalRegion,
+                                                             SIRVerticalRegion->Loc);
 }
 
-std::shared_ptr<dawn::BoundaryConditionDeclStmt>
+std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt>
 StencilParser::parseBoundaryCondition(clang::CXXConstructExpr* boundaryCondition) {
   using namespace clang;
   using namespace llvm;
@@ -966,7 +967,7 @@ StencilParser::parseBoundaryCondition(clang::CXXConstructExpr* boundaryCondition
   BoundaryConditionResolver resolver(this);
   resolver.resolve(boundaryCondition);
 
-  auto ASTBoundaryCondition = std::make_shared<dawn::BoundaryConditionDeclStmt>(
+  auto ASTBoundaryCondition = std::make_shared<dawn::sir::BoundaryConditionDeclStmt>(
       resolver.getFunctor(), getLocation(boundaryCondition));
 
   for(const auto& name : resolver.getFields()) {
@@ -989,13 +990,13 @@ StencilParser::parseBoundaryCondition(clang::CXXConstructExpr* boundaryCondition
   return ASTBoundaryCondition;
 }
 
-std::vector<std::shared_ptr<dawn::BoundaryConditionDeclStmt>>
+std::vector<std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt>>
 StencilParser::parseBoundaryConditions(clang::CXXMethodDecl* allBoundaryConditions) {
   using namespace clang;
   using namespace llvm;
   DAWN_LOG(INFO) << "Parsing all the boundary conditions at " << getLocation(allBoundaryConditions);
 
-  std::vector<std::shared_ptr<dawn::BoundaryConditionDeclStmt>> parsedBoundayConditions;
+  std::vector<std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt>> parsedBoundayConditions;
   CompoundStmt* bodyStmt = dyn_cast<CompoundStmt>(allBoundaryConditions->getBody());
 
   // loop over all the bounary condition stmts
@@ -1012,7 +1013,7 @@ StencilParser::parseBoundaryConditions(clang::CXXMethodDecl* allBoundaryConditio
 
         // create that DeclStmt with the functor and add the Fields / Arugments, where the field to
         // apply to is at Field[0] and all the arguments follow
-        auto bc = std::make_shared<dawn::BoundaryConditionDeclStmt>(res.getFunctor());
+        auto bc = std::make_shared<dawn::sir::BoundaryConditionDeclStmt>(res.getFunctor());
         for(const auto& field : res.getFields()) {
           bc->getFields().emplace_back(std::make_shared<dawn::sir::Field>(field));
         }

--- a/src/gtclang/Frontend/StencilParser.h
+++ b/src/gtclang/Frontend/StencilParser.h
@@ -145,23 +145,23 @@ private:
   void parseStencilFunctionDoMethod(clang::CXXMethodDecl* DoMethod);
 
   /// @brief Parse call to another stencil
-  std::shared_ptr<dawn::StencilCallDeclStmt> parseStencilCall(clang::CXXConstructExpr* stencilCall);
+  std::shared_ptr<dawn::sir::StencilCallDeclStmt> parseStencilCall(clang::CXXConstructExpr* stencilCall);
 
   /// @brief Parse a vertical-region
-  std::shared_ptr<dawn::VerticalRegionDeclStmt>
+  std::shared_ptr<dawn::sir::VerticalRegionDeclStmt>
   parseVerticalRegion(clang::CXXForRangeStmt* verticalRegionDecl);
 
   /// @brief Parse a decription of a boundary condition
-  std::shared_ptr<dawn::BoundaryConditionDeclStmt>
+  std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt>
   parseBoundaryCondition(clang::CXXConstructExpr* boundaryCondition);
 
   /// @brief Parses the MethodDeclaration that the preprocessor generates that contains all the
   /// boundary-condition statements
-  std::vector<std::shared_ptr<dawn::BoundaryConditionDeclStmt>>
+  std::vector<std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt>>
   parseBoundaryConditions(clang::CXXMethodDecl* allBoundaryConditions);
 
   /// @brief Resolve Clang AST statements by passing them to ClangASTResolver
-  std::shared_ptr<dawn::Stmt> resolveStmt(ClangASTExprResolver& clangASTResolver,
+  std::shared_ptr<dawn::sir::Stmt> resolveStmt(ClangASTExprResolver& clangASTResolver,
                                           clang::Stmt* stmt);
 
   /// @brief Get SourceLocation

--- a/src/gtclang/Unittest/ParsedString.cpp
+++ b/src/gtclang/Unittest/ParsedString.cpp
@@ -39,10 +39,10 @@ void ParsedString::dump() {
   std::cout << "all variables: " << dawn::RangeToString()(variables_) << std::endl;
 }
 
-void ParsedString::argumentParsingImpl(const std::shared_ptr<dawn::Expr>& argument) {
-  if(dawn::VarAccessExpr* expr = dawn::dyn_cast<dawn::VarAccessExpr>(argument.get())) {
+void ParsedString::argumentParsingImpl(const std::shared_ptr<dawn::sir::Expr>& argument) {
+  if(dawn::sir::VarAccessExpr* expr = dawn::dyn_cast<dawn::sir::VarAccessExpr>(argument.get())) {
     addVariable(expr->getName());
-  } else if(dawn::FieldAccessExpr* expr = dawn::dyn_cast<dawn::FieldAccessExpr>(argument.get())) {
+  } else if(dawn::sir::FieldAccessExpr* expr = dawn::dyn_cast<dawn::sir::FieldAccessExpr>(argument.get())) {
     addField(expr->getName());
   } else {
     dawn_unreachable("invalid expression");

--- a/src/gtclang/Unittest/ParsedString.h
+++ b/src/gtclang/Unittest/ParsedString.h
@@ -51,7 +51,7 @@ public:
   /// @brief recursive argument parsing to read all the fields given to specify the function call
   /// @{
   template <typename... Args>
-  void argumentParsing(const std::shared_ptr<dawn::Expr>& argument, Args&&... args) {
+  void argumentParsing(const std::shared_ptr<dawn::sir::Expr>& argument, Args&&... args) {
     argumentParsingImpl(argument);
     argumentParsing(std::forward<Args>(args)...);
   }
@@ -69,7 +69,7 @@ private:
   void addVariable(const std::string& variable) { variables_.push_back(variable); }
 
   /// @brief recursive argument parsing to read all the fields given to specify the function call
-  void argumentParsingImpl(const std::shared_ptr<dawn::Expr>& argument);
+  void argumentParsingImpl(const std::shared_ptr<dawn::sir::Expr>& argument);
 
   std::vector<std::string> fields_;
   std::vector<std::string> variables_;

--- a/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/src/gtclang/Unittest/ParsingComparison.cpp
@@ -184,7 +184,7 @@ private:
 };
 
 CompareResult ParsingComparison::compare(const ParsedString& ps,
-                                         const std::shared_ptr<dawn::Stmt>& stmt) {
+                                         const std::shared_ptr<dawn::sir::Stmt>& stmt) {
   std::unique_ptr<dawn::SIR> test01SIR = dawn::make_unique<dawn::SIR>();
   wrapStatementInStencil(test01SIR, stmt);
   test01SIR->Filename = "In Memory Generated SIR";
@@ -207,8 +207,8 @@ CompareResult ParsingComparison::compare(const ParsedString& ps,
 }
 
 CompareResult ParsingComparison::compare(const ParsedString& ps,
-                                         const std::shared_ptr<dawn::Expr>& expr) {
-  return compare(ps, std::make_shared<dawn::ExprStmt>(expr));
+                                         const std::shared_ptr<dawn::sir::Expr>& expr) {
+  return compare(ps, std::make_shared<dawn::sir::ExprStmt>(expr));
 }
 
 ParsingComparison* ParsingComparison::instance_ = nullptr;
@@ -220,24 +220,24 @@ ParsingComparison& ParsingComparison::getSingleton() {
 }
 
 void ParsingComparison::wrapStatementInStencil(std::unique_ptr<dawn::SIR>& sir,
-                                               const std::shared_ptr<dawn::Stmt>& stmt) {
+                                               const std::shared_ptr<dawn::sir::Stmt>& stmt) {
   using namespace dawn;
-  if(BlockStmt* blockstmt = dawn::dyn_cast<BlockStmt>(stmt.get())) {
+  if(sir::BlockStmt* blockstmt = dawn::dyn_cast<sir::BlockStmt>(stmt.get())) {
     sir->Stencils.push_back(std::make_shared<sir::Stencil>());
     sir->Stencils[0]->Name = "test01";
-    sir->Stencils[0]->StencilDescAst =
-        std::make_shared<AST>(std::make_shared<BlockStmt>(std::vector<std::shared_ptr<Stmt>>{
-            std::make_shared<VerticalRegionDeclStmt>(std::make_shared<sir::VerticalRegion>(
-                std::make_shared<AST>(std::make_shared<BlockStmt>(*blockstmt)),
+    sir->Stencils[0]->StencilDescAst = std::make_shared<sir::AST>(
+        std::make_shared<sir::BlockStmt>(std::vector<std::shared_ptr<sir::Stmt>>{
+            std::make_shared<sir::VerticalRegionDeclStmt>(std::make_shared<sir::VerticalRegion>(
+                std::make_shared<sir::AST>(std::make_shared<sir::BlockStmt>(*blockstmt)),
                 std::make_shared<sir::Interval>(sir::Interval::Start, sir::Interval::End),
                 sir::VerticalRegion::LoopOrderKind::LK_Forward))}));
-    auto allFields = dawn::getFieldFromStencilAST(sir->Stencils[0]->StencilDescAst);
+    auto allFields = dawn::sir::getFieldFromStencilAST(sir->Stencils[0]->StencilDescAst);
     for(const auto& a : allFields) {
       sir->Stencils[0]->Fields.push_back(std::make_shared<dawn::sir::Field>(a));
     }
   } else {
-    wrapStatementInStencil(sir,
-                           std::make_shared<BlockStmt>(std::vector<std::shared_ptr<Stmt>>{stmt}));
+    wrapStatementInStencil(
+        sir, std::make_shared<sir::BlockStmt>(std::vector<std::shared_ptr<sir::Stmt>>{stmt}));
   }
 }
 

--- a/src/gtclang/Unittest/ParsingComparison.h
+++ b/src/gtclang/Unittest/ParsingComparison.h
@@ -50,9 +50,9 @@ public:
   /// and and empty string if we have a mismatch, we get a human-readable message of what failed and
   /// false
   /// @{
-  CompareResult compare(const ParsedString& ps, const std::shared_ptr<dawn::Stmt>& stmt);
+  CompareResult compare(const ParsedString& ps, const std::shared_ptr<dawn::sir::Stmt>& stmt);
 
-  CompareResult compare(const ParsedString& ps, const std::shared_ptr<dawn::Expr>& expr);
+  CompareResult compare(const ParsedString& ps, const std::shared_ptr<dawn::sir::Expr>& expr);
   ///@}
 
   /// @brief get singleton instance
@@ -60,7 +60,7 @@ public:
 
 private:
   void wrapStatementInStencil(std::unique_ptr<dawn::SIR>& sir,
-                              const std::shared_ptr<dawn::Stmt>& stmt);
+                              const std::shared_ptr<dawn::sir::Stmt>& stmt);
   static ParsingComparison* instance_;
 };
 

--- a/src/gtclang/Unittest/UnittestStmtSimplifier.cpp
+++ b/src/gtclang/Unittest/UnittestStmtSimplifier.cpp
@@ -31,97 +31,97 @@ static dawn::Type stringToType(const std::string& typestring) {
   return retval;
 }
 
-std::shared_ptr<dawn::ExprStmt> expr(const std::shared_ptr<dawn::Expr>& expr) {
-  return std::make_shared<dawn::ExprStmt>(expr);
+std::shared_ptr<dawn::sir::ExprStmt> expr(const std::shared_ptr<dawn::sir::Expr>& expr) {
+  return std::make_shared<dawn::sir::ExprStmt>(expr);
 }
 
-std::shared_ptr<dawn::ReturnStmt> ret(const std::shared_ptr<dawn::Expr>& expr) {
-  return std::make_shared<dawn::ReturnStmt>(expr);
+std::shared_ptr<dawn::sir::ReturnStmt> ret(const std::shared_ptr<dawn::sir::Expr>& expr) {
+  return std::make_shared<dawn::sir::ReturnStmt>(expr);
 }
 
-std::shared_ptr<dawn::VarDeclStmt> vardecl(const std::string& type, const std::string& name,
-                                           const std::shared_ptr<dawn::Expr>& init,
+std::shared_ptr<dawn::sir::VarDeclStmt> vardecl(const std::string& type, const std::string& name,
+                                           const std::shared_ptr<dawn::sir::Expr>& init,
                                            const char* op) {
 
-  return vecdecl(type, name, std::vector<std::shared_ptr<dawn::Expr>>({init}), 0, op);
+  return vecdecl(type, name, std::vector<std::shared_ptr<dawn::sir::Expr>>({init}), 0, op);
 }
 
-std::shared_ptr<dawn::VarDeclStmt> vecdecl(const std::string& type, const std::string& name,
-                                           std::vector<std::shared_ptr<dawn::Expr>> initList,
+std::shared_ptr<dawn::sir::VarDeclStmt> vecdecl(const std::string& type, const std::string& name,
+                                           std::vector<std::shared_ptr<dawn::sir::Expr>> initList,
                                            int dimension, const char* op) {
   auto realtype = stringToType(type);
-  return std::make_shared<dawn::VarDeclStmt>(realtype, name, dimension, op, initList);
+  return std::make_shared<dawn::sir::VarDeclStmt>(realtype, name, dimension, op, initList);
 }
 
-std::shared_ptr<dawn::VerticalRegionDeclStmt>
+std::shared_ptr<dawn::sir::VerticalRegionDeclStmt>
 verticalRegion(const std::shared_ptr<dawn::sir::VerticalRegion>& verticalRegion) {
-  return std::make_shared<dawn::VerticalRegionDeclStmt>(verticalRegion);
+  return std::make_shared<dawn::sir::VerticalRegionDeclStmt>(verticalRegion);
 }
 
-std::shared_ptr<dawn::StencilCallDeclStmt>
+std::shared_ptr<dawn::sir::StencilCallDeclStmt>
 scdec(const std::shared_ptr<dawn::sir::StencilCall>& stencilCall) {
-  return std::make_shared<dawn::StencilCallDeclStmt>(stencilCall);
+  return std::make_shared<dawn::sir::StencilCallDeclStmt>(stencilCall);
 }
 
-std::shared_ptr<dawn::BoundaryConditionDeclStmt> boundaryCondition(const std::string& callee) {
-  return std::make_shared<dawn::BoundaryConditionDeclStmt>(callee);
+std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt> boundaryCondition(const std::string& callee) {
+  return std::make_shared<dawn::sir::BoundaryConditionDeclStmt>(callee);
 }
 
-std::shared_ptr<dawn::IfStmt> ifstmt(const std::shared_ptr<dawn::Stmt>& condExpr,
-                                     const std::shared_ptr<dawn::Stmt>& thenStmt,
-                                     const std::shared_ptr<dawn::Stmt>& elseStmt) {
-  return std::make_shared<dawn::IfStmt>(condExpr, thenStmt, elseStmt);
+std::shared_ptr<dawn::sir::IfStmt> ifstmt(const std::shared_ptr<dawn::sir::Stmt>& condExpr,
+                                     const std::shared_ptr<dawn::sir::Stmt>& thenStmt,
+                                     const std::shared_ptr<dawn::sir::Stmt>& elseStmt) {
+  return std::make_shared<dawn::sir::IfStmt>(condExpr, thenStmt, elseStmt);
 }
 
-std::shared_ptr<dawn::UnaryOperator> unop(const std::shared_ptr<dawn::Expr>& operand,
+std::shared_ptr<dawn::sir::UnaryOperator> unop(const std::shared_ptr<dawn::sir::Expr>& operand,
                                           const char* op) {
-  return std::make_shared<dawn::UnaryOperator>(operand, op);
+  return std::make_shared<dawn::sir::UnaryOperator>(operand, op);
 }
 
-std::shared_ptr<dawn::BinaryOperator> binop(const std::shared_ptr<dawn::Expr>& left, const char* op,
-                                            const std::shared_ptr<dawn::Expr>& right) {
-  return std::make_shared<dawn::BinaryOperator>(left, op, right);
+std::shared_ptr<dawn::sir::BinaryOperator> binop(const std::shared_ptr<dawn::sir::Expr>& left, const char* op,
+                                            const std::shared_ptr<dawn::sir::Expr>& right) {
+  return std::make_shared<dawn::sir::BinaryOperator>(left, op, right);
 }
 
-std::shared_ptr<dawn::AssignmentExpr> assign(const std::shared_ptr<dawn::Expr>& left,
-                                             const std::shared_ptr<dawn::Expr>& right,
+std::shared_ptr<dawn::sir::AssignmentExpr> assign(const std::shared_ptr<dawn::sir::Expr>& left,
+                                             const std::shared_ptr<dawn::sir::Expr>& right,
                                              const char* op) {
-  return std::make_shared<dawn::AssignmentExpr>(left, right, op);
+  return std::make_shared<dawn::sir::AssignmentExpr>(left, right, op);
 }
 
-std::shared_ptr<dawn::TernaryOperator> ternop(const std::shared_ptr<dawn::Expr>& cond,
-                                              const std::shared_ptr<dawn::Expr>& left,
-                                              const std::shared_ptr<dawn::Expr>& right) {
-  return std::make_shared<dawn::TernaryOperator>(cond, left, right);
+std::shared_ptr<dawn::sir::TernaryOperator> ternop(const std::shared_ptr<dawn::sir::Expr>& cond,
+                                              const std::shared_ptr<dawn::sir::Expr>& left,
+                                              const std::shared_ptr<dawn::sir::Expr>& right) {
+  return std::make_shared<dawn::sir::TernaryOperator>(cond, left, right);
 }
 
-std::shared_ptr<dawn::FunCallExpr> fcall(const std::string& callee) {
-  return std::make_shared<dawn::FunCallExpr>(callee);
+std::shared_ptr<dawn::sir::FunCallExpr> fcall(const std::string& callee) {
+  return std::make_shared<dawn::sir::FunCallExpr>(callee);
 }
 
-std::shared_ptr<dawn::StencilFunCallExpr> sfcall(const std::string& calee) {
-  return std::make_shared<dawn::StencilFunCallExpr>(calee);
+std::shared_ptr<dawn::sir::StencilFunCallExpr> sfcall(const std::string& calee) {
+  return std::make_shared<dawn::sir::StencilFunCallExpr>(calee);
 }
 
-std::shared_ptr<dawn::StencilFunArgExpr> arg(int direction, int offset, int argumentIndex) {
-  return std::make_shared<dawn::StencilFunArgExpr>(direction, offset, argumentIndex);
+std::shared_ptr<dawn::sir::StencilFunArgExpr> arg(int direction, int offset, int argumentIndex) {
+  return std::make_shared<dawn::sir::StencilFunArgExpr>(direction, offset, argumentIndex);
 }
 
-std::shared_ptr<dawn::VarAccessExpr> var(const std::string& name,
-                                         std::shared_ptr<dawn::Expr> index) {
-  return std::make_shared<dawn::VarAccessExpr>(name, index);
+std::shared_ptr<dawn::sir::VarAccessExpr> var(const std::string& name,
+                                         std::shared_ptr<dawn::sir::Expr> index) {
+  return std::make_shared<dawn::sir::VarAccessExpr>(name, index);
 }
 
-std::shared_ptr<dawn::FieldAccessExpr> field(const std::string& name, dawn::Array3i offset,
+std::shared_ptr<dawn::sir::FieldAccessExpr> field(const std::string& name, dawn::Array3i offset,
                                              dawn::Array3i argumentMap,
                                              dawn::Array3i argumentOffset, bool negateOffset) {
-  return std::make_shared<dawn::FieldAccessExpr>(name, offset, argumentMap, argumentOffset,
+  return std::make_shared<dawn::sir::FieldAccessExpr>(name, offset, argumentMap, argumentOffset,
                                                  negateOffset);
 }
 
-std::shared_ptr<dawn::LiteralAccessExpr> lit(const std::string& value,
+std::shared_ptr<dawn::sir::LiteralAccessExpr> lit(const std::string& value,
                                              dawn::BuiltinTypeID builtinType) {
-  return std::make_shared<dawn::LiteralAccessExpr>(value, builtinType);
+  return std::make_shared<dawn::sir::LiteralAccessExpr>(value, builtinType);
 }
 
 } // namespace sirgen

--- a/src/gtclang/Unittest/UnittestStmtSimplifier.h
+++ b/src/gtclang/Unittest/UnittestStmtSimplifier.h
@@ -27,33 +27,33 @@ namespace sirgen {
 class BlockWriter {
 public:
   template <typename... Args>
-  void recursiveBlock(const std::shared_ptr<dawn::Stmt>& statement, Args&&... args) {
+  void recursiveBlock(const std::shared_ptr<dawn::sir::Stmt>& statement, Args&&... args) {
     storage_.push_back(statement);
     recursiveBlock(std::forward<Args>(args)...);
   }
 
   template <typename... Args>
-  void recursiveBlock(const std::shared_ptr<dawn::Expr>& expression, Args&&... args) {
-    recursiveBlock(std::make_shared<dawn::ExprStmt>(expression), std::forward<Args>(args)...);
+  void recursiveBlock(const std::shared_ptr<dawn::sir::Expr>& expression, Args&&... args) {
+    recursiveBlock(std::make_shared<dawn::sir::ExprStmt>(expression), std::forward<Args>(args)...);
   }
 
   void recursiveBlock() {}
 
   template <typename... Args>
-  const std::vector<std::shared_ptr<dawn::Stmt>>&
-  createVec(const std::shared_ptr<dawn::Stmt>& statement, Args&&... args) {
+  const std::vector<std::shared_ptr<dawn::sir::Stmt>>&
+  createVec(const std::shared_ptr<dawn::sir::Stmt>& statement, Args&&... args) {
     recursiveBlock(statement, std::forward<Args>(args)...);
     return storage_;
   }
   template <typename... Args>
-  const std::vector<std::shared_ptr<dawn::Stmt>>& createVec(const std::shared_ptr<dawn::Expr>& expr,
+  const std::vector<std::shared_ptr<dawn::sir::Stmt>>& createVec(const std::shared_ptr<dawn::sir::Expr>& expr,
                                                             Args&&... args) {
     recursiveBlock(expr, std::forward<Args>(args)...);
     return storage_;
   }
 
 private:
-  std::vector<std::shared_ptr<dawn::Stmt>> storage_;
+  std::vector<std::shared_ptr<dawn::sir::Stmt>> storage_;
 };
 
 /// @brief simplification for generating SIR in memory
@@ -66,48 +66,48 @@ private:
 /// @ingroup unittest
 /// @{
 template <typename... Args>
-std::shared_ptr<dawn::BlockStmt> block(Args&&... args) {
+std::shared_ptr<dawn::sir::BlockStmt> block(Args&&... args) {
   BlockWriter bw;
   auto vec = bw.createVec(std::forward<Args>(args)...);
-  return std::make_shared<dawn::BlockStmt>(vec);
+  return std::make_shared<dawn::sir::BlockStmt>(vec);
 }
 
-std::shared_ptr<dawn::ExprStmt> expr(const std::shared_ptr<dawn::Expr>& expr);
-std::shared_ptr<dawn::ReturnStmt> ret(const std::shared_ptr<dawn::Expr>& expr);
-std::shared_ptr<dawn::VarDeclStmt> vardecl(const std::string& type, const std::string& name,
-                                           const std::shared_ptr<dawn::Expr>& init,
+std::shared_ptr<dawn::sir::ExprStmt> expr(const std::shared_ptr<dawn::sir::Expr>& expr);
+std::shared_ptr<dawn::sir::ReturnStmt> ret(const std::shared_ptr<dawn::sir::Expr>& expr);
+std::shared_ptr<dawn::sir::VarDeclStmt> vardecl(const std::string& type, const std::string& name,
+                                           const std::shared_ptr<dawn::sir::Expr>& init,
                                            const char* op = "=");
-std::shared_ptr<dawn::VarDeclStmt> vecdecl(const std::string& type, const std::string& name,
-                                           std::vector<std::shared_ptr<dawn::Expr>> initList,
+std::shared_ptr<dawn::sir::VarDeclStmt> vecdecl(const std::string& type, const std::string& name,
+                                           std::vector<std::shared_ptr<dawn::sir::Expr>> initList,
                                            int dimension = 0, const char* op = "=");
-std::shared_ptr<dawn::VerticalRegionDeclStmt>
+std::shared_ptr<dawn::sir::VerticalRegionDeclStmt>
 verticalRegion(const std::shared_ptr<dawn::sir::VerticalRegion>& verticalRegion);
-std::shared_ptr<dawn::StencilCallDeclStmt>
+std::shared_ptr<dawn::sir::StencilCallDeclStmt>
 scdec(const std::shared_ptr<dawn::sir::StencilCall>& stencilCall);
-std::shared_ptr<dawn::BoundaryConditionDeclStmt> boundaryCondition(const std::string& callee);
-std::shared_ptr<dawn::IfStmt> ifstmt(const std::shared_ptr<dawn::Stmt>& condExpr,
-                                     const std::shared_ptr<dawn::Stmt>& thenStmt,
-                                     const std::shared_ptr<dawn::Stmt>& elseStmt = nullptr);
-std::shared_ptr<dawn::UnaryOperator> unop(const std::shared_ptr<dawn::Expr>& operand,
+std::shared_ptr<dawn::sir::BoundaryConditionDeclStmt> boundaryCondition(const std::string& callee);
+std::shared_ptr<dawn::sir::IfStmt> ifstmt(const std::shared_ptr<dawn::sir::Stmt>& condExpr,
+                                     const std::shared_ptr<dawn::sir::Stmt>& thenStmt,
+                                     const std::shared_ptr<dawn::sir::Stmt>& elseStmt = nullptr);
+std::shared_ptr<dawn::sir::UnaryOperator> unop(const std::shared_ptr<dawn::sir::Expr>& operand,
                                           const char* op);
-std::shared_ptr<dawn::BinaryOperator> binop(const std::shared_ptr<dawn::Expr>& left, const char* op,
-                                            const std::shared_ptr<dawn::Expr>& right);
-std::shared_ptr<dawn::AssignmentExpr> assign(const std::shared_ptr<dawn::Expr>& left,
-                                             const std::shared_ptr<dawn::Expr>& right,
+std::shared_ptr<dawn::sir::BinaryOperator> binop(const std::shared_ptr<dawn::sir::Expr>& left, const char* op,
+                                            const std::shared_ptr<dawn::sir::Expr>& right);
+std::shared_ptr<dawn::sir::AssignmentExpr> assign(const std::shared_ptr<dawn::sir::Expr>& left,
+                                             const std::shared_ptr<dawn::sir::Expr>& right,
                                              const char* op = "=");
-std::shared_ptr<dawn::TernaryOperator> ternop(const std::shared_ptr<dawn::Expr>& cond,
-                                              const std::shared_ptr<dawn::Expr>& left,
-                                              const std::shared_ptr<dawn::Expr>& right);
-std::shared_ptr<dawn::FunCallExpr> fcall(const std::string& callee);
-std::shared_ptr<dawn::StencilFunCallExpr> sfcall(const std::string& calee);
-std::shared_ptr<dawn::StencilFunArgExpr> arg(int direction, int offset, int argumentIndex);
-std::shared_ptr<dawn::VarAccessExpr> var(const std::string& name,
-                                         std::shared_ptr<dawn::Expr> index = nullptr);
-std::shared_ptr<dawn::FieldAccessExpr>
+std::shared_ptr<dawn::sir::TernaryOperator> ternop(const std::shared_ptr<dawn::sir::Expr>& cond,
+                                              const std::shared_ptr<dawn::sir::Expr>& left,
+                                              const std::shared_ptr<dawn::sir::Expr>& right);
+std::shared_ptr<dawn::sir::FunCallExpr> fcall(const std::string& callee);
+std::shared_ptr<dawn::sir::StencilFunCallExpr> sfcall(const std::string& calee);
+std::shared_ptr<dawn::sir::StencilFunArgExpr> arg(int direction, int offset, int argumentIndex);
+std::shared_ptr<dawn::sir::VarAccessExpr> var(const std::string& name,
+                                         std::shared_ptr<dawn::sir::Expr> index = nullptr);
+std::shared_ptr<dawn::sir::FieldAccessExpr>
 field(const std::string& name, dawn::Array3i offset = dawn::Array3i{{0, 0, 0}},
       dawn::Array3i argumentMap = dawn::Array3i{{-1, -1, -1}},
       dawn::Array3i argumentOffset = dawn::Array3i{{0, 0, 0}}, bool negateOffset = false);
-std::shared_ptr<dawn::LiteralAccessExpr>
+std::shared_ptr<dawn::sir::LiteralAccessExpr>
 lit(const std::string& value, dawn::BuiltinTypeID builtinType = dawn::BuiltinTypeID::Integer);
 /// @}
 


### PR DESCRIPTION

## Technical Description

To update to dawn's new namespace organization. AST nodes and utils needed are now in namespace dawn::sir.

#### Example

`dawn::IfStmt` becomes `dawn::sir::IfStmt`

## Dependencies

MeteoSwiss-APN/dawn#246