### PR TITLE
Adding keyword to remove multiple files generated by tests

### DIFF
--- a/test/integration-test/IIRSerializer/NestedStencils.cpp
+++ b/test/integration-test/IIRSerializer/NestedStencils.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fwrite-iir -fno-codegen -o %filename%_gen.cpp
-// EXPECTED_FILE: OUTPUT:%filename%.2.iir REFERENCE:%filename%_ref.iir IGNORE:filename
+// EXPECTED_FILE: OUTPUT:%filename%.2.iir REFERENCE:%filename%_ref.iir IGNORE:filename DELETE:%filename%.0.iir,%filename%.1.iir
 
 #include "gridtools/clang_dsl.hpp"
 

--- a/test/utils/gtclang-tester/gtclang_tester/parser.py
+++ b/test/utils/gtclang-tester/gtclang_tester/parser.py
@@ -242,6 +242,7 @@ class ExpectedFile(object):
         self.__file_output = []
         self.__file_reference = []
         self.__ignored_nodes = []
+        self.__discarded_files = []
 
         commands = command.split(' ')
         for cmd in commands:
@@ -263,6 +264,12 @@ class ExpectedFile(object):
                 for node in ignored_nodes.split(','):
                     self.__ignored_nodes.append(node)
 
+            delete_idx = cmd.find("DELETE:")
+            if delete_idx >= 0:
+                discarded_files = cmd[delete_idx + len("DELETE:"):].rstrip()
+                for discarded_file in discarded_files.split(','):
+                    self.__discarded_files.append(path.join(dir, discarded_file))
+
         if len(self.__file_output) != len(self.__file_reference):
             report_fatal_error(
                 "%s:%i: mismatch of number of output and reference files" % (file, linenumber))
@@ -275,6 +282,9 @@ class ExpectedFile(object):
 
     def get_ignored_nodes(self):
         return self.__ignored_nodes
+
+    def get_discarded_files(self):
+        return self.__discarded_files
 
 
 class Test(object):

--- a/test/utils/gtclang-tester/gtclang_tester/runner.py
+++ b/test/utils/gtclang-tester/gtclang_tester/runner.py
@@ -156,6 +156,8 @@ class TestRunner(object):
                             has_failure = True
                         else:
                             remove(outputfile)
+                            for discarded_file in files.get_discarded_files():
+                                remove(discarded_file)
 
             # Check expected output
             out = stdout.split('\n')


### PR DESCRIPTION
Adding feature to python gtclang_tester that enables to specify which additional files should be removed from the test directory after test passes.
Adding the keyword to NestedStencils.cpp test, which is producing 3 .iir files.