### PR TITLE
C++17 migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(GTCLANG_HAS_CUDA)
 endif(GTCLANG_HAS_CUDA)
 
 # Set C++ standard
-yoda_set_cxx_standard(c++11)
+yoda_set_cxx_standard(c++17)
 
 # Set C++ flags (Note that the LLVM/Clang package might add some other flags)
 gtclang_set_cxx_flags()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##===------------------------------------------------------------------------------*- CMake -*-===##
 ##                         _       _
 ##                        | |     | |
-##                    __ _| |_ ___| | __ _ _ __   __ _ 
+##                    __ _| |_ ___| | __ _ _ __   __ _
 ##                   / _` | __/ __| |/ _` | '_ \ / _` |
 ##                  | (_| | || (__| | (_| | | | | (_| |
 ##                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
@@ -9,13 +9,13 @@
 ##                   |___/                       |___/
 ##
 ##
-##  This file is distributed under the MIT License (MIT). 
+##  This file is distributed under the MIT License (MIT).
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING 
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
       "Choose the type of build, options are: Debug Release RelWithDebInfo." FORCE)
 endif()
 
@@ -67,7 +67,7 @@ if(GTCLANG_HAS_CUDA)
 endif(GTCLANG_HAS_CUDA)
 
 # Set C++ standard
-yoda_set_cxx_standard(c++17)
+set(CMAKE_CXX_STANDARD 17)
 
 # Set C++ flags (Note that the LLVM/Clang package might add some other flags)
 gtclang_set_cxx_flags()
@@ -128,7 +128,7 @@ endif()
 yoda_enable_full_rpath("${DAWN_RPATH_DIR}")
 
 # Add clang-format target
-set(format_directories 
+set(format_directories
   "${CMAKE_SOURCE_DIR}/src"
   "${CMAKE_SOURCE_DIR}/test/unit-test"
 )
@@ -159,8 +159,7 @@ gtclang_gen_install_config()
 
 # Install headers
 install(
-  DIRECTORY src/ 
-  DESTINATION ${GTCLANG_INSTALL_INCLUDE_DIR} 
+  DIRECTORY src/
+  DESTINATION ${GTCLANG_INSTALL_INCLUDE_DIR}
   FILES_MATCHING PATTERN "*.h" PATTERN "*.inc" PATTERN "*.hpp"
 )
-

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -90,8 +90,8 @@ yoda_find_package(
   REQUIRED_VARS dawn_DIR
   ADDITIONAL
     DOWNLOAD_DIR ${YODA_DOWNLOAD_DIR}
-    GIT_REPOSITORY "git@github.com:MeteoSwiss-APN/dawn.git"
-    GIT_TAG "master" 
+    GIT_REPOSITORY "git@github.com:Stagno/dawn.git"
+    GIT_TAG "c++17-migration" 
     YODA_ROOT "${GTCLANG_YODA_SOURCE_DIR}"
     CMAKE_ARGS ${dawn_cmake_args}
 )

--- a/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/src/gtclang/Unittest/ParsingComparison.cpp
@@ -185,7 +185,7 @@ private:
 
 CompareResult ParsingComparison::compare(const ParsedString& ps,
                                          const std::shared_ptr<dawn::sir::Stmt>& stmt) {
-  std::unique_ptr<dawn::SIR> test01SIR = dawn::make_unique<dawn::SIR>();
+  std::unique_ptr<dawn::SIR> test01SIR = std::make_unique<dawn::SIR>();
   wrapStatementInStencil(test01SIR, stmt);
   test01SIR->Filename = "In Memory Generated SIR";
   std::string localPath = "gtclang/Frontend/" + UnittestEnvironment::getSingleton().testCaseName() +

--- a/test/integration-test/CMakeLists.txt
+++ b/test/integration-test/CMakeLists.txt
@@ -112,6 +112,7 @@ function(compile_generated_examples)
 endfunction(compile_generated_examples)
 
 function(cuda_compile_generated_examples)
+  yoda_set_cxx_standard(c++11)
   set(oneValueArgs BACKEND)
   set(multiValueArgs EXAMPLES)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -148,6 +149,7 @@ function(cuda_compile_generated_examples)
 
       add_test(NAME CTest-${example}_benchmarks_${backend}_cuda COMMAND ${CTEST_SUBMIT_COMMAND} $<TARGET_FILE:${example}_benchmarks_${backend}_cuda> 12 12 10 --gtest_output=xml:${example}_cuda_unittest.xml)
   endforeach()
+  yoda_set_cxx_standard(c++17)
 endfunction(cuda_compile_generated_examples)
 
 

--- a/test/integration-test/CMakeLists.txt
+++ b/test/integration-test/CMakeLists.txt
@@ -1,15 +1,15 @@
 ##===------------------------------------------------------------------------------*- CMake -*-===##
-##                         _       _                   
-##                        | |     | |                  
-##                    __ _| |_ ___| | __ _ _ __   __ _ 
+##                         _       _
+##                        | |     | |
+##                    __ _| |_ ___| | __ _ _ __   __ _
 ##                   / _` | __/ __| |/ _` | '_ \ / _` |
 ##                  | (_| | || (__| | (_| | | | | (_| |
 ##                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
 ##                    __/ |                       __/ |
-##                   |___/                       |___/ 
+##                   |___/                       |___/
 ##
 ##
-##  This file is distributed under the MIT License (MIT). 
+##  This file is distributed under the MIT License (MIT).
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
@@ -42,7 +42,7 @@ function(code_generate_examples)
       if(EXISTS "${cwd}/CodeGen/${example}.json")
         set(config_str "--config=${cwd}/CodeGen/${example}.json")
       endif()
-  
+
       if(CMAKE_BUILD_TYPE MATCHES DEBUG)
         set(config_str "${config_str}" "-fpass-verbose")
       endif(CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -51,23 +51,23 @@ function(code_generate_examples)
       # Add the specified compilerflags
       GET_COMPILER_FLAGS(${example} flags)
       set(config_str "${config_str}" "${flags}")
-  
+
       file(MAKE_DIRECTORY "${cwd}/CodeGen/generated/")
-  
+
       # Add make target
       add_custom_command( OUTPUT ${cwd}/CodeGen/generated/${example}_${backend}.cpp
         COMMAND $<TARGET_FILE:gtclang> "-backend=${backend}" ${config_str} "-o" "${cwd}/CodeGen/generated/${example}_${backend}.cpp"  "${cwd}/CodeGen/${example}.cpp"
         DEPENDS ${cwd}/CodeGen/${example}.cpp gtclang
       )
- 
+
       add_custom_target(${example}_${backend}_codegen ALL DEPENDS ${cwd}/CodeGen/generated/${example}_${backend}.cpp)
       set_source_files_properties(${cwd}/CodeGen/generated/${example}_${backend}.cpp PROPERTIES GENERATED TRUE)
- 
+
       add_custom_command(OUTPUT ${cwd}/CodeGen/generated/${example}_c++-naive.cpp
         COMMAND $<TARGET_FILE:gtclang> "-backend=c++-naive" ${config_str} "-o" "${cwd}/CodeGen/generated/${example}_c++-naive.cpp"  "${cwd}/CodeGen/${example}.cpp"
         DEPENDS ${cwd}/CodeGen/${example}.cpp gtclang
       )
- 
+
       add_custom_target(${example}_c++-naive_codegen ALL DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp)
       set_source_files_properties(${cwd}/CodeGen/generated/${example}_c++-naive.cpp PROPERTIES GENERATED TRUE)
 
@@ -82,7 +82,7 @@ function(compile_generated_examples)
   set(codegen_examples_ ${ARG_EXAMPLES})
   set(backend ${ARG_BACKEND})
 
-  if(NOT ${backend} STREQUAL "gt") 
+  if(NOT ${backend} STREQUAL "gt")
     message(FATAL "backend ${backend} not supported")
   endif()
 
@@ -105,14 +105,13 @@ function(compile_generated_examples)
 
 #      set_property(SOURCE ${cwd}/CodeGen/${example}_benchmark.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/CodeGen/generated/${example}_${backend}.cpp)
 #      set_property(SOURCE ${cwd}/CodeGen/${example}_benchmark.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp)
-  
+
       add_test(NAME CTest-${example}_benchmarks_${backend} COMMAND $<TARGET_FILE:${example}_benchmarks_${backend}> 12 12 10 --gtest_output=xml:${example}_unittest.xml)
-  
+
   endforeach()
 endfunction(compile_generated_examples)
 
 function(cuda_compile_generated_examples)
-  yoda_set_cxx_standard(c++11)
   set(oneValueArgs BACKEND)
   set(multiValueArgs EXAMPLES)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -142,20 +141,19 @@ function(cuda_compile_generated_examples)
         DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp
       )
 
-      if(CTEST_CUDA_SUBMIT) 
+      if(CTEST_CUDA_SUBMIT)
         string(REPLACE " " ";" GTCLANG_SLURM_RESOURCES_LIST ${GTCLANG_SLURM_RESOURCES})
         set(CTEST_SUBMIT_COMMAND "${SLURM_SRUN_COMMAND}" "-n" "${GTCLANG_SLURM_N_TASKS}" ${GTCLANG_SLURM_RESOURCES_LIST} "-p" "${GTCLANG_SLURM_PARTITION}")
       endif(CTEST_CUDA_SUBMIT)
 
       add_test(NAME CTest-${example}_benchmarks_${backend}_cuda COMMAND ${CTEST_SUBMIT_COMMAND} $<TARGET_FILE:${example}_benchmarks_${backend}_cuda> 12 12 10 --gtest_output=xml:${example}_cuda_unittest.xml)
   endforeach()
-  yoda_set_cxx_standard(c++17)
 endfunction(cuda_compile_generated_examples)
 
 
 set(cwd ${CMAKE_CURRENT_LIST_DIR})
 
-set(directories 
+set(directories
   ${cwd}/Accesses
   ${cwd}/Diagnostics
   ${cwd}/PassStageSplitter
@@ -208,7 +206,7 @@ if(GTCLANG_HAS_GRIDTOOLS)
 
   ADD_COMPILER_FLAG_TO_EXAMPLE("boundary_condition_2" "-max-fields=2")
   ADD_COMPILER_FLAG_TO_EXAMPLE("boundary_condition_2" "-fsplit-stencils")
-  
+
   ADD_COMPILER_FLAG_TO_EXAMPLE("boundary_condition" "-max-fields=2")
   ADD_COMPILER_FLAG_TO_EXAMPLE("boundary_condition" "-fsplit-stencils")
 

--- a/test/unit-test/gtclang/Support/TestMain.cpp
+++ b/test/unit-test/gtclang/Support/TestMain.cpp
@@ -21,7 +21,7 @@
 
 int main(int argc, char* argv[]) {
   // Initialize Logger
-  auto logger = dawn::make_unique<gtclang::Logger>();
+  auto logger = std::make_unique<gtclang::Logger>();
   dawn::Logger::getSingleton().registerLogger(logger.get());
 
   // Initialize GTest


### PR DESCRIPTION
Setting CMake to compile with c++17 standard.
Substituting additions to in STLExtras.h with the actual c++ 17 std:: versions

Depends on https://github.com/MeteoSwiss-APN/dawn/pull/276