### PR TITLE
Fix `LLVM ERROR: too many signal callbacks already registered`

### DIFF
--- a/src/gtclang/Driver/Driver.cpp
+++ b/src/gtclang/Driver/Driver.cpp
@@ -34,8 +34,8 @@ bool Driver::isInitialized = false;
 ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   // Print a stack trace if we signal out
   if(!isInitialized) {
-    llvm::sys::PrintStackTraceOnErrorSignal(
-        args[0]); // we must call this only once, otherwise we register a signal on each call
+    // we must call this only once, otherwise we register a signal on each call
+    llvm::sys::PrintStackTraceOnErrorSignal(args[0]);
     isInitialized = true;
   }
   llvm::PrettyStackTraceProgram X(args.size(), args.data());

--- a/src/gtclang/Driver/Driver.cpp
+++ b/src/gtclang/Driver/Driver.cpp
@@ -29,10 +29,15 @@
 
 namespace gtclang {
 
-ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
+bool Driver::isInitialized = false;
 
+ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   // Print a stack trace if we signal out
-  llvm::sys::PrintStackTraceOnErrorSignal(args[0]);
+  if(!isInitialized) {
+    llvm::sys::PrintStackTraceOnErrorSignal(
+        args[0]); // we must call this only once, otherwise we register a signal on each call
+    isInitialized = true;
+  }
   llvm::PrettyStackTraceProgram X(args.size(), args.data());
 
   // Call llvm_shutdown() on exit

--- a/src/gtclang/Driver/Driver.h
+++ b/src/gtclang/Driver/Driver.h
@@ -40,6 +40,8 @@ struct Driver : public dawn::NonCopyable {
   /// @returns The Stencil Intermediate Representation and an integer that is `0` on success, `1`
   /// otherwise
   static ReturnValue run(const llvm::SmallVectorImpl<const char*>& args);
+
+  static bool isInitialized;
 };
 
 } // namespace gtclang


### PR DESCRIPTION
I got the error when running tests which call `Driver::run` many times: LLVM ERROR: too many signal callbacks already registered.

Fix: Call `llvm::sys::PrintStackTraceOnErrorSignal(args[0])` only once.